### PR TITLE
Fix documentation regarding oldest_idlexact

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -3103,7 +3103,7 @@ sub check_oldest_2pc {
     return ok( $me, \@msg, \@perfdata );
 }
 
-=item B<oldest_xact> (8.3+)
+=item B<oldest_idlexact> (8.3+)
 
 Check the oldest I<idle> transaction.
 


### PR DESCRIPTION
In the documentation, the service was named "oldest_xact". Fix it to properly reflect the service name.
