### PR TITLE
Optimize table_bloat queries

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -4609,7 +4609,7 @@ sub check_table_bloat {
         # text types header is 4, page header is 20 and block size 8192 for 7.4.
         # page header is 24 and GUC block_size appears for 8.0
         $PG_VERSION_74 =>  q{
-          SELECT current_database(), schemaname, tblname, bs*tblpages AS real_size,
+          SELECT current_database(), ns.nspname AS schemaname, tblname, bs*tblpages AS real_size,
             NULL, NULL, NULL, (tblpages-est_num_pages)*bs AS bloat_size,
             CASE WHEN tblpages - est_num_pages > 0
               THEN 100 * (tblpages - est_num_pages)/tblpages::float
@@ -4618,19 +4618,19 @@ sub check_table_bloat {
           FROM (
             SELECT
               ceil( reltuples / ( (bs-page_hdr)/tpl_size ) ) + ceil( toasttuples / 4 ) AS est_num_pages, tblpages,
-              bs, tblid, schemaname, tblname, heappages, toastpages, is_na
+              bs, tblid, relnamespace, tblname, heappages, toastpages, is_na
             FROM (
               SELECT
                 ( 4 + tpl_hdr_size + tpl_data_size + (2*ma)
                   - CASE WHEN tpl_hdr_size%ma = 0 THEN ma ELSE tpl_hdr_size%ma END
                   - CASE WHEN ceil(tpl_data_size)::int%ma = 0 THEN ma ELSE ceil(tpl_data_size)::int%ma END
-                ) AS tpl_size, bs - page_hdr AS size_per_block, (heappages + toastpages) AS tblpages, heappages,
-                toastpages, reltuples, toasttuples, bs, page_hdr, tblid, schemaname, tblname, is_na
+                ) AS tpl_size, bs - page_hdr AS size_per_block, (heappages + coalesce(toast.relpages, 0)) AS tblpages, heappages,
+                coalesce(toast.relpages, 0) AS toastpages, s.reltuples,
+                coalesce(toast.reltuples, 0) AS toasttuples, bs, page_hdr, tblid, s.relnamespace, tblname, is_na
               FROM (
                 SELECT
-                  tbl.oid AS tblid, ns.nspname AS schemaname, tbl.relname AS tblname, tbl.reltuples,
-                  tbl.relpages AS heappages, coalesce(toast.relpages, 0) AS toastpages,
-                  coalesce(toast.reltuples, 0) AS toasttuples,
+                  tbl.oid AS tblid, tbl.relnamespace, tbl.relname AS tblname, tbl.reltuples,
+                  tbl.relpages AS heappages, tbl.reltoastrelid,
                   CASE WHEN cluster_version.v > 7
                     THEN current_setting('block_size')::numeric
                     ELSE 8192::numeric
@@ -4641,29 +4641,26 @@ sub check_table_bloat {
                     ELSE 20
                   END AS page_hdr,
                   CASE WHEN cluster_version.v > 7 THEN 27 ELSE 23 END
-                      + CASE WHEN MAX(coalesce(null_frac,0)) > 0 THEN ( 7 + count(*) ) / 8 ELSE 0::int END
+                      + CASE WHEN MAX(coalesce(stanullfrac,0)) > 0 THEN ( 7 + count(*) ) / 8 ELSE 0::int END
                       + CASE WHEN tbl.relhasoids THEN 4 ELSE 0 END AS tpl_hdr_size,
-                  sum( (1-coalesce(s.null_frac, 0)) * coalesce(s.avg_width, 1024) ) AS tpl_data_size,
+                  sum( (1-coalesce(s.stanullfrac, 0)) * coalesce(s.stawidth, 1024) ) AS tpl_data_size,
                   max( CASE WHEN att.atttypid = 'pg_catalog.name'::regtype THEN 1 ELSE 0 END ) > 0 AS is_na
                 FROM pg_attribute att
                   JOIN pg_class tbl ON att.attrelid = tbl.oid
-                  JOIN pg_namespace ns ON ns.oid = tbl.relnamespace
-                  JOIN pg_stats s ON s.schemaname=ns.nspname
-                    AND s.tablename = tbl.relname
-                    AND s.attname=att.attname
-                  LEFT JOIN pg_class toast ON tbl.reltoastrelid = toast.oid,
-                  ( SELECT substring(current_setting('server_version') FROM '#"[0-9]+#"%' FOR '#')::integer ) AS cluster_version(v)
+                  JOIN pg_statistic s ON s.starelid=tbl.oid
+                    AND s.staattnum=att.attnum
+                  CROSS JOIN ( SELECT substring(current_setting('server_version') FROM '#"[0-9]+#"%' FOR '#')::integer ) AS cluster_version(v)
                 WHERE att.attnum > 0 AND NOT att.attisdropped
                   AND tbl.relkind = 'r'
-                GROUP BY 1,2,3,4,5,6,7,8,9,10, cluster_version.v, tbl.relhasoids
-                ORDER BY 2,3
-              ) as s
+                GROUP BY 1,2,3,4,5,6,7,8,9, cluster_version.v, tbl.relhasoids
+              ) as s LEFT JOIN pg_class toast ON s.reltoastrelid = toast.oid
             ) as s2
-          ) AS s3
-          WHERE NOT is_na},
+          ) AS s3 JOIN pg_namespace AS ns ON ns.oid = s3.relnamespace
+          WHERE NOT is_na
+          ORDER BY ns.nspname,s3.tblname},
         # variable block size, page header is 24 and text types header is 1 or 4 for 8.3+
         $PG_VERSION_82 =>  q{
-          SELECT current_database(), schemaname, tblname, bs*tblpages AS real_size,
+          SELECT current_database(), ns.nspname AS schemaname, tblname, bs*tblpages AS real_size,
             (tblpages-est_tblpages)*bs AS extra_size,
             CASE WHEN tblpages - est_tblpages > 0
               THEN 100 * (tblpages - est_tblpages)/tblpages::float
@@ -4676,19 +4673,20 @@ sub check_table_bloat {
           FROM (
             SELECT ceil( reltuples / ( (bs-page_hdr)/tpl_size ) ) + ceil( toasttuples / 4 ) AS est_tblpages,
               ceil( reltuples / ( (bs-page_hdr)*fillfactor/(tpl_size*100) ) ) + ceil( toasttuples / 4 ) AS est_tblpages_ff,
-              tblpages, fillfactor, bs, tblid, schemaname, tblname, heappages, toastpages, is_na
+              tblpages, fillfactor, bs, tblid, relnamespace, tblname, heappages, toastpages, is_na
             FROM (
               SELECT
                 ( 4 + tpl_hdr_size + tpl_data_size + (2*ma)
                   - CASE WHEN tpl_hdr_size%ma = 0 THEN ma ELSE tpl_hdr_size%ma END
                   - CASE WHEN ceil(tpl_data_size)::int%ma = 0 THEN ma ELSE ceil(tpl_data_size)::int%ma END
-                ) AS tpl_size, bs - page_hdr AS size_per_block, (heappages + toastpages) AS tblpages, heappages,
-                toastpages, reltuples, toasttuples, bs, page_hdr, tblid, schemaname, tblname, fillfactor, is_na
+                ) AS tpl_size, bs - page_hdr AS size_per_block, (heappages + coalesce(toast.relpages, 0)) AS tblpages,
+                heappages, coalesce(toast.relpages, 0) AS toastpages,
+                s.reltuples, coalesce(toast.reltuples, 0) AS toasttuples,
+                bs, page_hdr, tblid, s.relnamespace, tblname, fillfactor, is_na
               FROM (
                 SELECT
-                  tbl.oid AS tblid, ns.nspname AS schemaname, tbl.relname AS tblname, tbl.reltuples,
-                  tbl.relpages AS heappages, coalesce(toast.relpages, 0) AS toastpages,
-                  coalesce(toast.reltuples, 0) AS toasttuples,
+                  tbl.oid AS tblid, tbl.relnamespace, tbl.relname AS tblname, tbl.reltuples, tbl.reltoastrelid,
+                  tbl.relpages AS heappages,
                   coalesce(substring(
                     array_to_string(tbl.reloptions, ' ')
                     FROM '%fillfactor=#"__#"%' FOR '#')::smallint, 100) AS fillfactor,
@@ -4696,27 +4694,27 @@ sub check_table_bloat {
                   CASE WHEN version()~'mingw32' OR version()~'64-bit|x86_64|ppc64|ia64|amd64' THEN 8 ELSE 4 END AS ma,
                   24 AS page_hdr,
                   CASE WHEN current_setting('server_version_num')::integer < 80300 THEN 27 ELSE 23 END
-                    + CASE WHEN MAX(coalesce(null_frac,0)) > 0 THEN ( 7 + count(*) ) / 8 ELSE 0::int END
+                    + CASE WHEN MAX(coalesce(s.stanullfrac,0)) > 0 THEN ( 7 + count(*) ) / 8 ELSE 0::int END
                     + CASE WHEN tbl.relhasoids THEN 4 ELSE 0 END AS tpl_hdr_size,
-                  sum( (1-coalesce(s.null_frac, 0)) * coalesce(s.avg_width, 1024) ) AS tpl_data_size,
+                  sum( (1-coalesce(s.stanullfrac, 0)) * coalesce(s.stawidth, 1024) ) AS tpl_data_size,
                   bool_or(att.atttypid = 'pg_catalog.name'::regtype) AS is_na
                 FROM pg_attribute AS att
                   JOIN pg_class AS tbl ON att.attrelid = tbl.oid
-                  JOIN pg_namespace AS ns ON ns.oid = tbl.relnamespace
-                  JOIN pg_stats AS s ON s.schemaname=ns.nspname
-                    AND s.tablename = tbl.relname AND s.attname=att.attname
+                  JOIN pg_statistic s
+                    ON s.starelid = tbl.oid AND s.staattnum=att.attnum
                   LEFT JOIN pg_class AS toast ON tbl.reltoastrelid = toast.oid
                 WHERE att.attnum > 0 AND NOT att.attisdropped
                   AND tbl.relkind = 'r'
                 GROUP BY 1,2,3,4,5,6,7,8,9,10, tbl.relhasoids
                 ORDER BY 2,3
-              ) AS s
-            ) AS s2
-          ) AS s3
-          WHERE NOT is_na},
+              ) as s LEFT JOIN pg_class toast ON s.reltoastrelid = toast.oid
+            ) as s2
+          ) AS s3 JOIN pg_namespace AS ns ON ns.oid = s3.relnamespace
+          WHERE NOT is_na
+          ORDER BY ns.nspname,s3.tblname},
         # exclude inherited stats
         $PG_VERSION_90 =>  q{
-          SELECT current_database(), schemaname, tblname, bs*tblpages AS real_size,
+          SELECT current_database(), nspname AS schemaname, tblname, bs*tblpages AS real_size,
             (tblpages-est_tblpages)*bs AS extra_size,
             CASE WHEN tblpages - est_tblpages > 0
               THEN 100 * (tblpages - est_tblpages)/tblpages::float
@@ -4729,43 +4727,41 @@ sub check_table_bloat {
           FROM (
             SELECT ceil( reltuples / ( (bs-page_hdr)/tpl_size ) ) + ceil( toasttuples / 4 ) AS est_tblpages,
               ceil( reltuples / ( (bs-page_hdr)*fillfactor/(tpl_size*100) ) ) + ceil( toasttuples / 4 ) AS est_tblpages_ff,
-              tblpages, fillfactor, bs, tblid, schemaname, tblname, heappages, toastpages, is_na
+              tblpages, fillfactor, bs, tblid, relnamespace, tblname, heappages, toastpages, is_na
             FROM (
               SELECT
                 ( 4 + tpl_hdr_size + tpl_data_size + (2*ma)
                   - CASE WHEN tpl_hdr_size%ma = 0 THEN ma ELSE tpl_hdr_size%ma END
                   - CASE WHEN ceil(tpl_data_size)::int%ma = 0 THEN ma ELSE ceil(tpl_data_size)::int%ma END
-                ) AS tpl_size, bs - page_hdr AS size_per_block, (heappages + toastpages) AS tblpages, heappages,
-                toastpages, reltuples, toasttuples, bs, page_hdr, tblid, schemaname, tblname, fillfactor, is_na
+                ) AS tpl_size, bs - page_hdr AS size_per_block, (heappages + coalesce(toast.relpages, 0)) AS tblpages,
+                heappages, coalesce(toast.relpages, 0) AS toastpages, s.reltuples,
+                coalesce(toast.reltuples, 0) toasttuples, bs, page_hdr, tblid, s.relnamespace, tblname, fillfactor, is_na
               FROM (
                 SELECT
-                  tbl.oid AS tblid, ns.nspname AS schemaname, tbl.relname AS tblname, tbl.reltuples,
-                  tbl.relpages AS heappages, coalesce(toast.relpages, 0) AS toastpages,
-                  coalesce(toast.reltuples, 0) AS toasttuples,
+                  tbl.oid AS tblid, tbl.relnamespace, tbl.relname AS tblname, tbl.reltoastrelid, tbl.reltuples,
+                  tbl.relpages AS heappages,
                   coalesce(substring(
                     array_to_string(tbl.reloptions, ' ')
                     FROM '%fillfactor=#"__#"%' FOR '#')::smallint, 100) AS fillfactor,
                   current_setting('block_size')::numeric AS bs,
                   CASE WHEN version()~'mingw32' OR version()~'64-bit|x86_64|ppc64|ia64|amd64' THEN 8 ELSE 4 END AS ma,
                   24 AS page_hdr,
-                  23 + CASE WHEN MAX(coalesce(null_frac,0)) > 0 THEN ( 7 + count(*) ) / 8 ELSE 0::int END
+                  23 + CASE WHEN MAX(coalesce(s.stanullfrac,0)) > 0 THEN ( 7 + count(*) ) / 8 ELSE 0::int END
                     + CASE WHEN tbl.relhasoids THEN 4 ELSE 0 END AS tpl_hdr_size,
-                  sum( (1-coalesce(s.null_frac, 0)) * coalesce(s.avg_width, 1024) ) AS tpl_data_size,
+                  sum( (1-coalesce(s.stanullfrac, 0)) * coalesce(s.stawidth, 1024) ) AS tpl_data_size,
                   bool_or(att.atttypid = 'pg_catalog.name'::regtype) AS is_na
                 FROM pg_attribute AS att
                   JOIN pg_class AS tbl ON att.attrelid = tbl.oid
-                  JOIN pg_namespace AS ns ON ns.oid = tbl.relnamespace
-                  JOIN pg_stats AS s ON s.schemaname=ns.nspname
-                    AND s.tablename = tbl.relname AND s.inherited=false AND s.attname=att.attname
-                  LEFT JOIN pg_class AS toast ON tbl.reltoastrelid = toast.oid
+                  JOIN pg_statistic AS s ON s.starelid = tbl.oid AND s.stainherit=false AND s.staattnum=att.attnum
                 WHERE att.attnum > 0 AND NOT att.attisdropped
                   AND tbl.relkind = 'r'
-                GROUP BY 1,2,3,4,5,6,7,8,9,10, tbl.relhasoids
+                GROUP BY 1,2,3,4,5,6,7,8,9, tbl.relhasoids
                 ORDER BY 2,3
-              ) AS s
-            ) AS s2
-          ) AS s3
-          WHERE NOT is_na}
+              ) as s LEFT JOIN pg_class toast ON s.reltoastrelid = toast.oid
+            ) as s2
+          ) AS s3 JOIN pg_namespace AS ns ON ns.oid = s3.relnamespace
+          WHERE NOT is_na
+          ORDER BY ns.nspname,s3.tblname}
     );
 
     # warning and critical are mandatory.


### PR DESCRIPTION
Use pg_statistic instead of pg_stats in order to do some table scans later in
the query plan.

Original patch by Ronan Dunklau, 7.4-8.1 adapted by me.