### PR TITLE
Add support for PostgreSQL 9.6 and fix backends_status

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -72,6 +72,7 @@ my $PG_VERSION_92  = 90200;
 my $PG_VERSION_93  = 90300;
 my $PG_VERSION_94  = 90400;
 my $PG_VERSION_95  = 90500;
+my $PG_VERSION_96  = 90600;
 
 # reference to the output sub
 my $output_fmt;

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -1839,6 +1839,22 @@ sub check_backends_status {
             FROM pg_stat_activity AS s
               JOIN pg_database d ON d.oid=s.datid
             WHERE d.datallowconn
+        },
+        # pg_stat_activity schema change for wait events
+        $PG_VERSION_96 => q{
+            SELECT CASE
+                WHEN s.wait_event = 'Lock' THEN 'waiting for lock'
+                WHEN s.query = '<insufficient privilege>'
+                    THEN 'insufficient privilege'
+                WHEN s.state IS NULL THEN 'undefined'
+                ELSE s.state
+              END,
+              extract('epoch' FROM
+                date_trunc('milliseconds', current_timestamp-s.xact_start)
+              ), s.query, current_setting('max_connections')
+            FROM pg_stat_activity AS s
+              JOIN pg_database d ON d.oid=s.datid
+            WHERE d.datallowconn
         }
     );
 


### PR DESCRIPTION
The pg_stat_activity schema has changed again with PostgreSQL 9.6. The wait events monitoring adds some more complexity to monitor lock waits. This first attempt adds only a case for heavyweight locks to appears as sessions waiting for lock. The bufferpin and LWlock event types are not taken in account right now. We should probably add some new perfdata for those, but this will come later.