### PR TITLE
Fix query_ver to work with PostgreSQL 10 and up

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -976,7 +976,7 @@ sub query_ver($\%;$) {
 
     set_pgversion($host);
 
-    foreach my $ver ( sort { $b cmp $a } keys %queries ) {
+    foreach my $ver ( sort { $b <=> $a } keys %queries ) {
         return query( $host, $queries{$ver}, $db )
             if ( $ver <= $host->{'version_num'} );
     }


### PR DESCRIPTION
This modification was forgotten as the version handling has been reworked.