### PR TITLE
Fix typo that prevents backends_status to report waiting backends from 9.6+

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -1860,7 +1860,7 @@ sub check_backends_status {
         # pg_stat_activity schema change for wait events
         $PG_VERSION_96 => q{
             SELECT CASE
-                WHEN s.wait_event = 'Lock' THEN 'waiting for lock'
+                WHEN s.wait_event_type = 'Lock' THEN 'waiting for lock'
                 WHEN s.query = '<insufficient privilege>'
                     THEN 'insufficient privilege'
                 WHEN s.state IS NULL THEN 'undefined'


### PR DESCRIPTION
Hello,

Sorry, my query was wrong was I fixed backends_status for PostgreSQL 9.6 in commit edc4cf818f67a420d1c9104a6c8ace3ead1c0446. Waiting queries are not reported. This patch fixes this issue for heavyweight locks. There is still some room for improvement to support the new wait_event infrastructure, I hope to bring a better shaped patch next week.

Regards
