### PR TITLE
Fix stat_snapshot_age minversion in perldoc

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -6437,7 +6437,7 @@ sub check_wal_files {
     return ok( $me, \@msg, \@perfdata );
 }
 
-=item B<stat_snapshot_age> (8.1+)
+=item B<stat_snapshot_age> (9.5+)
 
 Check the age of the statistics snapshot (statistics collector's statistics).
 This probe help to detect a frozen stats collector process.


### PR DESCRIPTION
Min version was wrong in perldoc for check_stat_snapshot_age.