### PR TITLE
Another bunch of PostgreSQL 10 compatibility fixes

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -6290,7 +6290,7 @@ sub check_wal_files {
           max_nb_wal,
           CASE WHEN pg_is_in_recovery()
             THEN NULL
-            ELSE pg_current_xlog_location()
+            ELSE pg_current_wal_location()
           END,
           current_setting('wal_keep_segments')::integer
         FROM pg_ls_dir('pg_wal') AS s(f)

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5154,7 +5154,8 @@ sub check_replication_slots {
     my @rs;
     my %args = %{ $_[0] };
 
-    my $query   = q{
+    my %queries = (
+       $PG_VERSION_94 => q{
         WITH wal_size AS (
             SELECT current_setting('wal_block_size')::int * setting::int AS val
             FROM pg_settings
@@ -5170,8 +5171,25 @@ sub check_replication_slots {
             ),0
         )
         FROM pg_replication_slots slot
-        CROSS JOIN wal_size s
-    };
+        CROSS JOIN wal_size s},
+       $PG_VERSION_100 => q{
+        WITH wal_size AS (
+            SELECT current_setting('wal_block_size')::int * setting::int AS val
+            FROM pg_settings
+            WHERE name = 'wal_segment_size'
+        )
+        SELECT slot.slot_name,
+        COALESCE(
+            floor(
+                (pg_wal_location_diff(pg_current_wal_location(), slot.restart_lsn)
+                - (pg_walfile_name_offset(restart_lsn)).file_offset
+                )
+                / (s.val)
+            ),0
+        )
+        FROM pg_replication_slots slot
+        CROSS JOIN wal_size s}
+    );
 
     @hosts = @{ parse_hosts %args };
 
@@ -5191,7 +5209,7 @@ sub check_replication_slots {
             and  $args{'critical'} =~ m/^([0-9]+)$/;
     }
 
-    @rs = @{ query( $hosts[0], $query ) };
+    @rs = @{ query_ver( $hosts[0], %queries ) };
 
 SLOTS_LOOP: foreach my $row (@rs) {
         push @perfdata => [ $row->[0], $row->[1] ];

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -3630,7 +3630,8 @@ sub check_is_replay_paused {
     my $c_limit = -1;
     my %args    = %{ $_[0] };
     my $me      = 'POSTGRES_REPLICATION_PAUSED';
-    my $query   = q{
+    my %queries = (
+	$PG_VERSION_91 => q{
         SELECT pg_is_in_recovery()::int AS is_in_recovery,
         CASE pg_is_in_recovery()
             WHEN 't' THEN pg_is_xlog_replay_paused()::int
@@ -3645,8 +3646,24 @@ sub check_is_replay_paused {
                 THEN 1::int
             WHEN pg_is_in_recovery() THEN 0::int
             ELSE NULL
-        END AS delta
-    };
+        END AS delta},
+	$PG_VERSION_100 => q{
+        SELECT pg_is_in_recovery()::int AS is_in_recovery,
+        CASE pg_is_in_recovery()
+            WHEN 't' THEN pg_is_wal_replay_paused()::int
+            ELSE 0::int
+        END AS is_paused,
+        CASE pg_is_in_recovery()
+            WHEN 't' THEN extract('epoch' FROM now()-pg_last_xact_replay_timestamp())::int
+            ELSE NULL::int
+        END AS lag,
+        CASE
+            WHEN pg_is_in_recovery() AND pg_last_wal_replay_location() <> pg_last_wal_receive_location()
+                THEN 1::int
+            WHEN pg_is_in_recovery() THEN 0::int
+            ELSE NULL
+        END AS delta}
+    );
 
     if ( defined $args{'warning'} and defined $args{'critical'} ) {
         # warning and critical must be interval if provided.
@@ -3668,7 +3685,7 @@ sub check_is_replay_paused {
 
     is_compat $hosts[0], "is_replay_paused", $PG_VERSION_91 or exit 1;
 
-    @rs = @{ query( $hosts[0], $query )->[0] };
+    @rs = @{ query_ver( $hosts[0], %queries )->[0] };
 
     return unknown ( $me,
         [ "Server is not standby." ],

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -3284,7 +3284,8 @@ sub check_hot_standby_delta {
     my $me              = 'POSTGRES_HOT_STANDBY_DELTA';
     # we need to coalesce on pg_last_xlog_receive_location because it returns
     # NULL during WAL Shipping
-    my $query = "
+    my %queries = (
+	$PG_VERSION_90 => q{
         SELECT (NOT pg_is_in_recovery())::int,
             CASE pg_is_in_recovery()
                 WHEN 't' THEN coalesce(
@@ -3297,7 +3298,21 @@ sub check_hot_standby_delta {
                 WHEN 't' THEN pg_last_xlog_replay_location()
                 ELSE NULL
             END
-    ";
+	    },
+	$PG_VERSION_100 => q{
+        SELECT (NOT pg_is_in_recovery())::int,
+            CASE pg_is_in_recovery()
+                WHEN 't' THEN coalesce(
+                    pg_last_wal_receive_location(),
+                    pg_last_wal_replay_location()
+                )
+                ELSE pg_current_wal_location()
+            END,
+            CASE pg_is_in_recovery()
+                WHEN 't' THEN pg_last_wal_replay_location()
+                ELSE NULL
+            END
+	    });
 
     @hosts = @{ parse_hosts %args };
 
@@ -3312,7 +3327,7 @@ sub check_hot_standby_delta {
 
     # fetch LSNs
     foreach my $host (@hosts) {
-        $host->{'rs'} = \@{ query( $host, $query )->[0] };
+        $host->{'rs'} = \@{ query_ver( $host, %queries )->[0] };
         $num_clusters += $host->{'rs'}[0];
         $master_location = $host->{'rs'}[1] if $host->{'rs'}[0];
     }

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5388,6 +5388,10 @@ sub check_streaming_delta {
     my $master_location = '';
     my $num_clusters    = 0;
     my %queries         = (
+        $PG_VERSION_100 => q{SELECT application_name, client_addr, pid,
+            sent_location, write_location, flush_location, replay_location,
+            CASE pg_is_in_recovery() WHEN true THEN pg_last_wal_receive_location() ELSE pg_current_wal_location() END
+            FROM pg_stat_replication},
         $PG_VERSION_92 => q{SELECT application_name, client_addr, pid,
             sent_location, write_location, flush_location, replay_location,
             CASE pg_is_in_recovery() WHEN true THEN pg_last_xlog_receive_location() ELSE pg_current_xlog_location() END


### PR DESCRIPTION
Commit 806091c96f9b81f7631e4e37a05af377b473b5da in PostgreSQL source tree renamed all pg_*xlog* functions to pg_*wal* to remain consistent with the renaming of pg_xlog to pg_wal.

