### PR TITLE
Do not return pg_basebackup replication in streaming_delta

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5522,15 +5522,18 @@ sub check_streaming_delta {
         $PG_VERSION_100 => q{SELECT application_name, client_addr, pid,
             sent_location, write_location, flush_location, replay_location,
             CASE pg_is_in_recovery() WHEN true THEN pg_last_wal_receive_location() ELSE pg_current_wal_location() END
-            FROM pg_stat_replication},
+            FROM pg_stat_replication
+	    WHERE application_name <> 'pg_basebackup'},
         $PG_VERSION_92 => q{SELECT application_name, client_addr, pid,
             sent_location, write_location, flush_location, replay_location,
             CASE pg_is_in_recovery() WHEN true THEN pg_last_xlog_receive_location() ELSE pg_current_xlog_location() END
-            FROM pg_stat_replication},
+            FROM pg_stat_replication
+	    WHERE application_name <> 'pg_basebackup'},
         $PG_VERSION_91 => q{SELECT application_name, client_addr, procpid,
             sent_location, write_location, flush_location, replay_location,
             CASE pg_is_in_recovery() WHEN true THEN pg_last_xlog_receive_location() ELSE pg_current_xlog_location() END
-            FROM pg_stat_replication}
+            FROM pg_stat_replication
+	    WHERE application_name <> 'pg_basebackup'}
     );
     # FIXME this service should check for given slaves in opts!
 


### PR DESCRIPTION
I think, pg_basebackup should not be returned by streaming_delta because it not a "normal" replication steam.
We just launch pg_basebackup in particular cases.