### PR TITLE
Add --exclude option in check_streaming_delta

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5491,8 +5491,7 @@ Either of the two following examples will check for the presence of two slaves:
   --slave 'slave1 192.168.1.11','slave2 192.168.1.12'
 
 This service supports a C<--exclude REGEX>  parameter to exclude every result
-matching the given regular expression. This allows you to filter either on an
-application_name or address IP or whatever you want.
+matching the given regular expression on application_name or address ip fields.
 
 You can use multiple C<--exclude REGEX>  parameters.
 
@@ -5558,18 +5557,16 @@ sub check_streaming_delta {
 
     @rs = @{ query_ver( $hosts[0], %queries ) };
 
-    my $index = 0;
+    my $excluded = 0;
     if (@exclude){
         foreach my $line (@rs){
-	    foreach my $exclude_re (@exclude){
-	        if (grep { $_ =~ $exclude_re } @{$line}){
-	            delete $rs[$index];
+	        if ((grep { @{$line}[0] =~ m/$_/ } @exclude) || (grep { @{$line}[1] =~ m/$_/ } @exclude)){
+		        $excluded++;
 	        }
-	    }
-	    $index++;
-	}
+	     }
     }
-	
+
+	push @perfdata => [ '# of excluded slaves', $excluded ];
     push @perfdata => [ '# of slaves', scalar @rs || 0 ];
 
     return unknown( $me, ['No slaves connected'], \@perfdata )

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5514,6 +5514,7 @@ sub check_streaming_delta {
     my @hosts;
     my %slaves;
     my %args            = %{ $_[0] };
+    my @exclude      = @{ $args{'exclude'} };
     my $wal_size        = hex('ff000000');
     my $me              = 'POSTGRES_STREAMING_DELTA';
     my $master_location = '';
@@ -5551,6 +5552,18 @@ sub check_streaming_delta {
 
     @rs = @{ query_ver( $hosts[0], %queries ) };
 
+    my $index = 0;
+    if (@exclude){
+        foreach my $line (@rs){
+	    foreach my $exclude_re (@exclude){
+	        if (grep { $_ =~ $exclude_re } @{$line}){
+	            delete $rs[$index];
+	        }
+	    }
+	    $index++;
+	}
+    }
+	
     push @perfdata => [ '# of slaves', scalar @rs || 0 ];
 
     return unknown( $me, ['No slaves connected'], \@perfdata )
@@ -5663,7 +5676,7 @@ A critical alert is raised if an unlogged table is detected.
 
 This service supports both C<--dbexclude>  and C<--dbinclude> parameters.
 
-This service supports a C<--exclude REGEX>  parameter to exclude relations
+This service supports a C<--exclude REGEX>  parameter to exclud relations
 matching the given regular expression. The regular expression applies to
 "database.schema_name.relation_name". This allows you to filter either on a
 relation name for all schemas and databases, filter on a qualified named relation

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5490,6 +5490,12 @@ Either of the two following examples will check for the presence of two slaves:
   --slave 'slave1 192.168.1.11' --slave 'slave2 192.168.1.12'
   --slave 'slave1 192.168.1.11','slave2 192.168.1.12'
 
+This service supports a C<--exclude REGEX>  parameter to exclude every result
+matching the given regular expression. This allows you to filter either on an
+application_name or address IP or whatever you want.
+
+You can use multiple C<--exclude REGEX>  parameters.
+
 Perfdata returns the data delta in bytes between the master and all standbys
 found and the number of slaves connected.
 
@@ -5676,7 +5682,7 @@ A critical alert is raised if an unlogged table is detected.
 
 This service supports both C<--dbexclude>  and C<--dbinclude> parameters.
 
-This service supports a C<--exclude REGEX>  parameter to exclud relations
+This service supports a C<--exclude REGEX>  parameter to exclude relations
 matching the given regular expression. The regular expression applies to
 "database.schema_name.relation_name". This allows you to filter either on a
 relation name for all schemas and databases, filter on a qualified named relation


### PR DESCRIPTION
As discussed in PR #89 , here the PR which add --exclude option available for streaming_delta service.

We can exclude every pattern we want from the sql result.