### PR TITLE
make it possible to run check_pgactivity without connection parameters.

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -882,6 +882,10 @@ sub parse_hosts(\%) {
         }
     }
 
+    if (!@hosts) {
+	push(@hosts, {'name' => 'localhost/default'});
+    }
+
     dprint ('Hosts: '. Dumper(\@hosts));
 
     return \@hosts;

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -508,9 +508,10 @@ sub save($$$$) {
 
     if (defined $host->{'dbservice'}) {
         $hostkey = "$host->{'dbservice'}";
-    }
-    else {
+    } elsif (defined $host->{'host'}) {
         $hostkey = "$host->{'host'}$host->{'port'}";
+    } else {
+	$hostkey = "localhost/default"
     }
 
     die "File «${storage}» not recognized as a check_pgactivity status file.\n\n"
@@ -541,9 +542,10 @@ sub load($$$) {
 
     if (defined $host->{'dbservice'}) {
         $hostkey = "$host->{'dbservice'}";
-    }
-    else {
+    } elsif (defined $host->{'host'}) {
         $hostkey = "$host->{'host'}$host->{'port'}";
+    } else {
+	$hostkey = "localhost/default"
     }
 
     return undef unless -r $storage;


### PR DESCRIPTION
Redoing pull request #94, fix for issue #92 