### PR TITLE
Some more PostgreSQL 10 fixes

### DIFF
--- a/README
+++ b/README
@@ -343,6 +343,10 @@ check_pgactivity
         perfdata. This list contains the fully qualified bloated index name,
         the estimated bloat size, the index size and the bloat percentage.
 
+        This service will work with PostgreSQL 10+ without superuser privileges
+        if you grant SELECT on table pg_statistic to the pg_monitor role, in
+        each database of the cluster : GRANT SELECT ON pg_statistic TO pg_monitor;
+
     commit_ratio (all)
         Check the commit and rollback rate per second since last call.
 
@@ -813,6 +817,10 @@ check_pgactivity
         perfdata. This list contains the fully qualified bloated table name,
         the estimated bloat size, the table size and the bloat percentage.
 
+        This service will work with PostgreSQL 10+ without superuser privileges
+        if you grant SELECT on table pg_statistic to the pg_monitor role, in
+        each database of the cluster : GRANT SELECT ON pg_statistic TO pg_monitor;
+
     temp_files (8.1+)
         Check the number and size of temp files.
 
@@ -834,6 +842,9 @@ check_pgactivity
 
         Threshols applied on current temp files beeing created AND the
         number/size of temp files created since last execution.
+
+        This service will not work with PostgreSQL 10+ without superuser
+        privileges.
 
     wal_files (8.1+)
         Check the number of WAL files.
@@ -920,5 +931,5 @@ check_pgactivity
 
   AUTHORS
     Author: Open PostgreSQL Monitoring Development Group Copyright: (C)
-    2012-2016 Open PostgreSQL Development Group
+    2012-2017 Open PostgreSQL Development Group
 

--- a/README.pod
+++ b/README.pod
@@ -378,6 +378,10 @@ A list of the bloated indexes detail will be returned after the
 perfdata. This list contains the fully qualified bloated index name, the
 estimated bloat size, the index size and the bloat percentage.
 
+This service will work with PostgreSQL 10+ without superuser privileges
+if you grant SELECT on table pg_statistic to the pg_monitor role, in
+each database of the cluster : C<GRANT SELECT ON pg_statistic TO pg_monitor;>
+
 =item B<commit_ratio> (all)
 
 Check the commit and rollback rate per second since last call.
@@ -853,6 +857,10 @@ A list of the bloated tables detail will be returned after the
 perfdata. This list contains the fully qualified bloated table name, the
 estimated bloat size, the table size and the bloat percentage.
 
+This service will work with PostgreSQL 10+ without superuser privileges
+if you grant SELECT on table pg_statistic to the pg_monitor role, in
+each database of the cluster : C<GRANT SELECT ON pg_statistic TO pg_monitor;>
+
 =item B<temp_files> (8.1+)
 
 Check the number and size of temp files.
@@ -873,6 +881,8 @@ values separated by a comma.
 
 Threshols applied on current temp files beeing created AND the number/size
 of temp files created since last execution.
+
+This service will not work with PostgreSQL 10+ without superuser privileges.
 
 =item B<wal_files> (8.1+)
 
@@ -958,7 +968,7 @@ B<It has to be executed locally on the monitored server.>
 
 =head2 VERSION
 
-check_pgactivity version 2.2_rc1, released on Tue Feb 28 2017.
+check_pgactivity version 2.2_rc2, released on Wed Mar 1 2017.
 
 =head2 LICENSING
 
@@ -968,5 +978,5 @@ For license terms, see the LICENSE provided with the sources.
 =head2 AUTHORS
 
 Author: Open PostgreSQL Monitoring Development Group
-Copyright: (C) 2012-2016 Open PostgreSQL Development Group
+Copyright: (C) 2012-2017 Open PostgreSQL Development Group
 

--- a/README.pod
+++ b/README.pod
@@ -968,7 +968,7 @@ B<It has to be executed locally on the monitored server.>
 
 =head2 VERSION
 
-check_pgactivity version 2.2_rc2, released on Wed Mar 1 2017.
+check_pgactivity version 2.2, released on Fri Apr 28 2017.
 
 =head2 LICENSING
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -6418,7 +6418,7 @@ sub check_wal_files {
           FROM pg_settings
           WHERE name = 'max_wal_size'
         )
-        SELECT s.f,
+        SELECT s.name,
           max_nb_wal,
           CASE WHEN pg_is_in_recovery()
             THEN NULL
@@ -6426,12 +6426,12 @@ sub check_wal_files {
           END,
           current_setting('wal_keep_segments')::integer,
           (pg_control_checkpoint()).timeline_id AS tli
-        FROM pg_ls_dir('pg_wal') AS s(f)
+        FROM pg_ls_waldir() AS s
         CROSS JOIN wal_settings
-        WHERE f ~ '^[0-9A-F]{24}$'
+        WHERE name ~ '^[0-9A-F]{24}$'
         ORDER BY
-          (pg_stat_file('pg_wal/'||s,true)).modification DESC,
-          f DESC},
+          s.modification DESC,
+          name DESC},
      $PG_VERSION_95 => q{
         WITH wal_settings AS (
           SELECT setting::int + current_setting('wal_keep_segments')::int as max_nb_wal

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -1085,6 +1085,26 @@ sub is_compat($$$;$) {
     return 1;
 }
 
+# Check host compatibility
+sub silent_is_compat($$$;$) {
+    my $host    = shift;
+    my $service = shift;
+    my $min     = shift;
+    my $max     = shift() || 9999999;;
+    my $ver;
+
+    set_pgversion($host);
+    $ver = 100*int($host->{'version_num'}/100);
+
+    return 0 unless (
+        $ver >= $min
+        and $ver <= $max
+    );
+
+    return 1;
+
+}
+
 sub dprint {
     return unless $args{'debug'};
     foreach (@_) {
@@ -5206,7 +5226,7 @@ sub check_archiver {
 
     is_compat $hosts[0], 'archiver', $PG_VERSION_81 or exit 1;
 
-    if (is_compat $hosts[0], 'archiver', $PG_VERSION_81, $PG_VERSION_96) {
+    if (silent_is_compat $hosts[0], 'archiver', $PG_VERSION_81, $PG_VERSION_96) {
         # cf. pgarch_readyXlog in src/backend/postmaster/pgarch.c about how the
         # archiver process pick the next WAL to archive.
         # We try to reproduce the same algo here

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5185,25 +5185,6 @@ sub check_archiver {
     my $nb_files;
     my %args  = %{ $_[0] };
     my $me    = 'POSTGRES_ARCHIVER';
-    # cf. pgarch_readyXlog in src/backend/postmaster/pgarch.c about how the
-    # archiver process pick the next WAL to archive.
-    # We try to reproduce the same algo here
-    my %queries = (
-       $PG_VERSION_81 => q{
-           SELECT s.f,
-             extract(epoch from (pg_stat_file('pg_xlog/archive_status/'||s.f)).modification),
-             extract(epoch from current_timestamp)
-           FROM pg_ls_dir('pg_xlog/archive_status') AS s(f)
-           WHERE f ~ '^[0123456789ABCDEF.history.backup.partial]{16,40}\.ready$'
-           ORDER BY s.f ASC},
-       $PG_VERSION_100 => q{
-           SELECT s.f,
-             extract(epoch from (pg_stat_file('pg_wal/archive_status/'||s.f)).modification),
-             extract(epoch from current_timestamp)
-           FROM pg_ls_dir('pg_wal/archive_status') AS s(f)
-           WHERE f ~ '^[0123456789ABCDEF.history.backup.partial]{16,40}\.ready$'
-           ORDER BY s.f ASC}
-    );
 
     # warning and critical must be raw
     pod2usage(
@@ -5221,33 +5202,82 @@ sub check_archiver {
 
     is_compat $hosts[0], 'archiver', $PG_VERSION_81 or exit 1;
 
-    $prev_archiving = load( $hosts[0], 'archiver', $args{'status-file'} ) || '';
+    if (is_compat $hosts[0], 'archiver', $PG_VERSION_81, $PG_VERSION_96) {
+        # cf. pgarch_readyXlog in src/backend/postmaster/pgarch.c about how the
+        # archiver process pick the next WAL to archive.
+        # We try to reproduce the same algo here
+        my $query = qq{
+           SELECT s.f,
+             extract(epoch from (pg_stat_file('pg_xlog/archive_status/'||s.f)).modification),
+             extract(epoch from current_timestamp)
+           FROM pg_ls_dir('pg_xlog/archive_status') AS s(f)
+           WHERE f ~ '^[0123456789ABCDEF.history.backup.partial]{16,40}\.ready$'
+           ORDER BY s.f ASC};
 
-    @rs = @{ query_ver( $hosts[0], %queries ) };
 
-    $nb_files = scalar @rs;
+        $prev_archiving = load( $hosts[0], 'archiver', $args{'status-file'} ) || '';
 
-    push @perfdata => [ 'ready_archive', $nb_files, undef, $args{'warning'}, $args{'critical'}, 0 ];
+        @rs = @{ query( $hosts[0], $query ) };
 
-    if ( $nb_files > 0 ) {
-        push @perfdata => [ 'oldest_ready_wal', int( $rs[0][2] - $rs[0][1] ), 's',
-                            undef, undef, 0 ];
+        $nb_files = scalar @rs;
 
-        if ( $rs[0][0] ne $prev_archiving ) {
-            save $hosts[0], 'archiver', $rs[0][0], $args{'status-file'};
+        push @perfdata => [ 'ready_archive', $nb_files, undef, $args{'warning'}, $args{'critical'}, 0 ];
+
+        if ( $nb_files > 0 ) {
+            push @perfdata => [ 'oldest_ready_wal', int( $rs[0][2] - $rs[0][1] ), 's',
+                                undef, undef, 0 ];
+
+            if ( $rs[0][0] ne $prev_archiving ) {
+                save $hosts[0], 'archiver', $rs[0][0], $args{'status-file'};
+            }
+            else {
+                push @msg => sprintf 'archiver stalling', substr($rs[0][0], 0, 24);
+                push @longmsg => sprintf '"%s" not archived since last check',
+                                    substr($rs[0][0], 0, -6);
+            }
         }
         else {
-            push @msg => sprintf 'archiver stalling', substr($rs[0][0], 0, 24);
-            push @longmsg => sprintf '"%s" not archived since last check',
-                                substr($rs[0][0], 0, -6);
+            push @perfdata => [ 'oldest_ready_wal', 0, 's', undef, undef, 0 ];
+            save $hosts[0], 'archiver', '', $args{'status-file'};
         }
+
+        push @msg => "$nb_files WAL files ready to archive";
+
     }
     else {
-        push @perfdata => [ 'oldest_ready_wal', 0, 's', undef, undef, 0 ];
-        save $hosts[0], 'archiver', '', $args{'status-file'};
-    }
+	# Version 10.0 and higher: use pg_stat_archiver as the monitoring
+	# user may not be super-user.
+        my $query = qq{
+        SELECT (('x' || substr(current_wal, 9, 8))::bit(32)::int *256 + ('x' || substr(current_wal, 17, 8))::bit(32)::int)
+             - (('x' || substr(last_failed_wal, 9, 8))::bit(32)::int * 256 + ('x' || substr(last_failed_wal, 17, 8))::bit(32)::int) AS ready_archives,
+               extract('epoch' from (current_timestamp - last_failed_time)) AS oldest_archive_failure
+          FROM (SELECT CASE WHEN   (last_failed_time >= last_archived_time)
+                                OR (last_archived_time IS NULL AND last_failed_time IS NOT NULL)
+                            THEN last_failed_wal
+                            ELSE NULL
+                       END AS last_failed_wal,
+                       pg_walfile_name(pg_current_wal_location()) as current_wal,
+                       last_failed_time
+                  FROM pg_stat_archiver) stats 
+        };
 
-    push @msg => "$nb_files WAL files ready to archive";
+        @rs = @{ query( $hosts[0], $query ) };
+
+        $nb_files = $rs[0][0];
+
+        push @perfdata => [ 'ready_archive', $nb_files, undef, $args{'warning'}, $args{'critical'}, 0 ];
+
+        if ( $nb_files > 0 ) {
+            push @perfdata => [ 'oldest_ready_wal', int( $rs[0][1] ), 's',
+                                undef, undef, 0 ];
+        }
+        else {
+            push @perfdata => [ 'oldest_ready_wal', 0, 's', undef, undef, 0 ];
+        }
+
+        push @msg => "$nb_files WAL files ready to archive";
+
+    }
 
     return critical( $me, \@msg, \@perfdata, \@longmsg ) if scalar @msg > 1;
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -6792,7 +6792,7 @@ sub check_sequences_exhausted {
         next ALLDB_LOOP if @dbinclude and not grep { $db =~ /$_/ } @dbinclude;
 
         # We have two code paths: one for < 10.0 and one for >=10.S
-        if (is_compat $hosts[0], 'sequences_exhausted', $PG_VERSION_82, $PG_VERSION_96)
+        if (silent_is_compat $hosts[0], 'sequences_exhausted', $PG_VERSION_82, $PG_VERSION_96)
         {
             # Search path is emptied so that ::regclass gives us full paths
             my $query  = qq{

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -57,7 +57,7 @@ delete $ENV{'LANGUAGE'};
 
 $| = 1;
 
-$VERSION = '2.2_rc1';
+$VERSION = '2.2';
 $PROGRAM = 'check_pgactivity';
 
 my $PG_VERSION_MIN =  70400;
@@ -3424,13 +3424,13 @@ sub check_hot_standby_delta {
         SELECT (NOT pg_is_in_recovery())::int,
             CASE pg_is_in_recovery()
                 WHEN 't' THEN coalesce(
-                    pg_last_wal_receive_location(),
-                    pg_last_wal_replay_location()
+                    pg_last_wal_receive_lsn(),
+                    pg_last_wal_replay_lsn()
                 )
-                ELSE pg_current_wal_location()
+                ELSE pg_current_wal_lsn()
             END,
             CASE pg_is_in_recovery()
-                WHEN 't' THEN pg_last_wal_replay_location()
+                WHEN 't' THEN pg_last_wal_replay_lsn()
                 ELSE NULL
             END
     });
@@ -5280,7 +5280,7 @@ sub check_archiver {
                             THEN last_failed_wal
                             ELSE NULL
                        END AS last_failed_wal,
-                       pg_walfile_name(pg_current_wal_location()) as current_wal,
+                       pg_walfile_name(pg_current_wal_lsn()) as current_wal,
                        last_failed_time
                   FROM pg_stat_archiver) stats 
         };
@@ -5364,7 +5364,7 @@ sub check_replication_slots {
         SELECT slot.slot_name,
         COALESCE(
             floor(
-                (pg_wal_location_diff(pg_current_wal_location(), slot.restart_lsn)
+                (pg_wal_lsn_diff(pg_current_wal_lsn(), slot.restart_lsn)
                 - (pg_walfile_name_offset(restart_lsn)).file_offset
                 )
                 / (s.val)
@@ -5574,8 +5574,8 @@ sub check_streaming_delta {
     my $num_clusters    = 0;
     my %queries         = (
         $PG_VERSION_100 => q{SELECT application_name, client_addr, pid,
-            sent_location, write_location, flush_location, replay_location,
-            CASE pg_is_in_recovery() WHEN true THEN pg_last_wal_receive_location() ELSE pg_current_wal_location() END
+            sent_lsn, write_lsn, flush_lsn, replay_lsn,
+            CASE pg_is_in_recovery() WHEN true THEN pg_last_wal_receive_lsn() ELSE pg_current_wal_lsn() END
             FROM pg_stat_replication},
         $PG_VERSION_92 => q{SELECT application_name, client_addr, pid,
             sent_location, write_location, flush_location, replay_location,
@@ -6482,7 +6482,7 @@ sub check_wal_files {
           max_nb_wal,
           CASE WHEN pg_is_in_recovery()
             THEN NULL
-            ELSE pg_current_wal_location()
+            ELSE pg_current_wal_lsn()
           END,
           current_setting('wal_keep_segments')::integer,
           (pg_control_checkpoint()).timeline_id AS tli
@@ -7243,7 +7243,7 @@ __END__
 
 =head2 VERSION
 
-check_pgactivity version 2.2_rc2, released on Wed Mar 1 2017.
+check_pgactivity version 2.2, released on Fri Apr 28 2017.
 
 =head2 LICENSING
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -1062,7 +1062,7 @@ sub set_pgversion($) {
     return 1;
 }
 
-# Check host compatibility
+# Check host compatibility, with warning
 sub is_compat($$$;$) {
     my $host    = shift;
     my $service = shift;
@@ -1085,8 +1085,8 @@ sub is_compat($$$;$) {
     return 1;
 }
 
-# Check host compatibility
-sub silent_is_compat($$$;$) {
+# Check host compatibility, without warning
+sub check_compat($$$;$) {
     my $host    = shift;
     my $service = shift;
     my $min     = shift;
@@ -5226,7 +5226,7 @@ sub check_archiver {
 
     is_compat $hosts[0], 'archiver', $PG_VERSION_81 or exit 1;
 
-    if (silent_is_compat $hosts[0], 'archiver', $PG_VERSION_81, $PG_VERSION_96) {
+    if (check_compat $hosts[0], 'archiver', $PG_VERSION_81, $PG_VERSION_96) {
         # cf. pgarch_readyXlog in src/backend/postmaster/pgarch.c about how the
         # archiver process pick the next WAL to archive.
         # We try to reproduce the same algo here
@@ -6792,7 +6792,7 @@ sub check_sequences_exhausted {
         next ALLDB_LOOP if @dbinclude and not grep { $db =~ /$_/ } @dbinclude;
 
         # We have two code paths: one for < 10.0 and one for >=10.S
-        if (silent_is_compat $hosts[0], 'sequences_exhausted', $PG_VERSION_82, $PG_VERSION_96)
+        if (check_compat $hosts[0], 'sequences_exhausted', $PG_VERSION_82, $PG_VERSION_96)
         {
             # Search path is emptied so that ::regclass gives us full paths
             my $query  = qq{

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -2327,6 +2327,10 @@ A list of the bloated indexes detail will be returned after the
 perfdata. This list contains the fully qualified bloated index name, the
 estimated bloat size, the index size and the bloat percentage.
 
+This service will work with PostgreSQL 10+ without superuser privileges
+if you grant SELECT on table pg_statistic to the pg_monitor role, in
+each database of the cluster : C<GRANT SELECT ON pg_statistic TO pg_monitor;>
+
 =cut
 
 sub check_btree_bloat {
@@ -5830,6 +5834,10 @@ A list of the bloated tables detail will be returned after the
 perfdata. This list contains the fully qualified bloated table name, the
 estimated bloat size, the table size and the bloat percentage.
 
+This service will work with PostgreSQL 10+ without superuser privileges
+if you grant SELECT on table pg_statistic to the pg_monitor role, in
+each database of the cluster : C<GRANT SELECT ON pg_statistic TO pg_monitor;>
+
 =cut
 
 sub check_table_bloat {
@@ -6106,6 +6114,8 @@ values separated by a comma.
 
 Threshols applied on current temp files beeing created AND the number/size
 of temp files created since last execution.
+
+This service will not work with PostgreSQL 10+ without superuser privileges.
 
 =cut
 
@@ -7213,7 +7223,7 @@ __END__
 
 =head2 VERSION
 
-check_pgactivity version 2.2_rc1, released on Tue Feb 28 2017.
+check_pgactivity version 2.2_rc2, released on Wed Mar 1 2017.
 
 =head2 LICENSING
 
@@ -7223,6 +7233,6 @@ For license terms, see the LICENSE provided with the sources.
 =head2 AUTHORS
 
 Author: Open PostgreSQL Monitoring Development Group
-Copyright: (C) 2012-2016 Open PostgreSQL Development Group
+Copyright: (C) 2012-2017 Open PostgreSQL Development Group
 
 =cut

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -1877,7 +1877,7 @@ sub check_backends_status {
                         THEN 'waiting for lock'
                     ELSE 'active'
                 END AS status,
-                NULL, s.current_query, current_setting('max_connections')
+                NULL, current_setting('max_connections')
             FROM pg_stat_activity AS s
                 JOIN pg_database d ON d.oid=s.datid
             WHERE d.datallowconn
@@ -1904,7 +1904,7 @@ sub check_backends_status {
                 extract('epoch' FROM
                     date_trunc('milliseconds', current_timestamp-s.xact_start)
                 ),
-                s.current_query, current_setting('max_connections')
+                current_setting('max_connections')
             FROM pg_stat_activity AS s
                 JOIN pg_database d ON d.oid=s.datid
             WHERE d.datallowconn
@@ -1933,7 +1933,7 @@ sub check_backends_status {
                 extract('epoch' FROM
                     date_trunc('milliseconds', current_timestamp-s.xact_start)
                 ),
-                s.current_query, current_setting('max_connections')
+                current_setting('max_connections')
             FROM pg_stat_activity AS s
                 JOIN pg_database d ON d.oid=s.datid
             WHERE d.datallowconn
@@ -1949,7 +1949,7 @@ sub check_backends_status {
               END,
               extract('epoch' FROM
                 date_trunc('milliseconds', current_timestamp-s.xact_start)
-              ), s.query, current_setting('max_connections')
+              ), current_setting('max_connections')
             FROM pg_stat_activity AS s
               JOIN pg_database d ON d.oid=s.datid
             WHERE d.datallowconn
@@ -1966,7 +1966,7 @@ sub check_backends_status {
               END,
               extract('epoch' FROM
                 date_trunc('milliseconds', current_timestamp-s.xact_start)
-              ), s.query, current_setting('max_connections')
+              ), current_setting('max_connections')
             FROM pg_stat_activity AS s
               JOIN pg_database d ON d.oid=s.datid
             WHERE d.datallowconn
@@ -2014,7 +2014,7 @@ sub check_backends_status {
     delete $status{'other wait event'}
         if $hosts[0]->{'version_num'} < $PG_VERSION_96;
 
-    $max_connections = $rs[0][3] if scalar @rs;
+    $max_connections = $rs[0][2] if scalar @rs;
 
     REC_LOOP: foreach my $r (@rs) {
 


### PR DESCRIPTION
This bunch of commits take account of the new pg_monitor role in PostgreSQL 10.

Using this feature, we'll be able to use an unprivileged monitoring user. The following services were changed : 
  * wal_files
  * archiver

The btree_bloat and table_bloat services still works but one needs to grant the SELECT privilege on table pg_statistic to pg_monitor, inside each monitored databases, otherwise the check will fail. This is of course documented.

Also, one generic fix concerns the backends_status service. The query column was retrieved but was not used at all. Now this service simply retrieves actually used columns.
