### PR TITLE
Integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+- ./dockertest.sh 9.2
+- ./dockertest.sh 9.3
+- ./dockertest.sh 9.4
+- ./dockertest.sh 9.5
+- ./dockertest.sh 9.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+XXXX-XX-XX WIP:
+  - add ``test.sh`` and ``dockertest.sh``
+	- add TravisCI integration
+  - add a ``CONTRIBUTING`` file
+
+
 2017-04-28 v2.2:
   - add support for PostgreSQL 9.6
   - add early-support for PostgreSQL 10

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+How To Contribute
+===============================================================================
+
+
+Submit a patch
+------------------------------------------------------------------------------
+
+Before sending a Pull Request, please run the ``dockertest.sh`` script to check
+that your code works on every current PostgreSQL major versions. For instance,
+the command below will check that your version runs correctly on Postgres 9.4:
+
+```
+./dockertest.sh 9.4
+```
+

--- a/README.pod
+++ b/README.pod
@@ -1,3 +1,5 @@
+=for html <a href="https://travis-ci.org/daamien/check_pgactivity"><img src="https://travis-ci.org/daamien/check_pgactivity.svg?branch=travis"></a>
+
 =head1 check_pgactivity
 
 check_pgactivity - PostgreSQL plugin for Nagios

--- a/dockertest.sh
+++ b/dockertest.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Usage : dockercheck.sh [VERSION]
+# with:
+#    VERSION : PostgreSQL major version
+# 
+
+if [ "$1" = "" ]; then
+	PG_VERSION=9.6
+else
+	PG_VERSION=$1
+fi
+
+CONTAINER=test_check_pgactivity_$PG_VERSION
+
+docker run -d --name $CONTAINER postgres:$PG_VERSION > /dev/null
+
+# load test into the 
+docker cp . $CONTAINER:/tmp/
+
+# wait for the database to come up	
+sleep 10
+	
+# launch test
+docker exec $CONTAINER bash -x /tmp/test.sh $PG_VERSION
+rc=$?
+
+# clean up	
+docker rm -f $CONTAINER > /dev/null
+
+exit $rc

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# $1 is required 
+# Should be a major postgresql version
+# i.e. : 7.4, 8.0, 8.1, 8.2, 8.3, 8.4, 9.0, 9.1, 9.2, 9.3, 9.4 , 9.5, 9.6, 10
+
+HOST=localhost
+STATUS_FILE=/tmp/check_pgactivity.data
+C=`dirname $0`/check_pgactivity 
+
+#
+# check_pgactivity returns 0 for OK, 1 for CRITICAL, 2 for WARNING
+# These are considered as "correct" exit codes 
+# Any higher exit code is considered as an error
+#
+check(){
+[[ $1 -gt 2 ]] && exit $1 
+}
+
+#
+# Put your all-version services below 
+#
+
+# archive_folder
+#$C -s archive_folder --path /var/lib/postgresql/$1/main/pg_xlog || check $?
+
+# backends
+$C -s backends -h $HOST -w '10%' -c '30%' || check $?
+
+# btree_bloat
+$C -s btree_bloat -h $HOST -w '10%' -c '30%' || check $?
+
+# commit_ratio
+$C -s commit_ratio --status-file $STATUS_FILE -h $HOST || check $?
+$C -s commit_ratio --status-file $STATUS_FILE -h $HOST -w 'rollbacks=10' -c 'rollbacks=100' || check $?
+
+[[ "$1" == "7.4" ]] &&  exit 0
+
+#
+# Put your 8.0+ servicess below 
+# 
+
+# configuration
+$C -s configuration --work_mem 1024 -h $HOST || check $?
+$C -s configuration --maintenance_work_mem 1024 -h $HOST || check $? 
+$C -s configuration --shared_buffers 10 -h $HOST || check $?
+$C -s configuration --shared_buffers 10 -h $HOST || check $?
+$C -s configuration --wal_buffers 10 -h $HOST || check $?
+$C -s configuration --checkpoint_segments 10 -h $HOST || check $?
+$C -s configuration --effective_cache_size 1024 -h $HOST || check $?
+$C -s configuration --no_check_autovacuum  -h $HOST || check $?
+$C -s configuration --no_check_fsync -h $HOST || check $?
+$C -s configuration --no_check_enable -h $HOST || check $?
+$C -s configuration --no_check_track_counts -h $HOST || check $?
+
+[[ "$1" == "8.0" ]] &&  exit 0
+
+#
+# Put your 8.1+ servicess below 
+#
+
+# autovacuum:
+$C -s autovacuum -h $HOST || check $?
+
+# backup_label_age
+$C -s backup_label_age -h $HOST -w 1h30m25s -c 28h30m || check $?
+
+[[ "$1" == "8.1" ]] &&  exit 0
+# Put your 8.2+ servicess below 
+
+# last_analyze
+$C -s last_analyze --status-file $STATUS_FILE -h $HOST -w 30m -c 1h30m || check $?
+
+# last_vacuum
+$C -s last_vacuum --status-file $STATUS_FILE -h $HOST -w 30m -c 1h30m || check $?
+
+# backend_status
+$C -s backends_status -h $HOST -w 'waiting=5,idle_xact=10' -c 'waiting=20,idle_xact=30' || check $?
+
+
+[[ "$1" == "8.2" ]] &&  exit 0
+
+#
+# Put your 8.3+ servicess below 
+#
+
+# bgwriter
+$C -s bgwriter --status-file $STATUS_FILE -h $HOST || check $?
+# /!\ Illegal division by zero at /tmp/check_pgactivity line 2271.
+#$C -s bgwriter --status-file $STATUS_FILE -h $HOST -w 15% -c 33% || check $?
+


### PR DESCRIPTION

This patch contains 3 main changes:

* A ``test.sh`` file that runs basic check_pgactivity lines and stops if there's an error. The file is not complete yet, this is just a PoC. The script takes the major version as parameter

* A ``dockertest.sh`` that launches the ``test.sh`` inside any official docker postgres image (see https://hub.docker.com/_/postgres/ ).  The script takes the major version as parameter

* A ``Travis CI config file`` that launches ``dockertest.sh`` on every major version from 9.2 to 9.6. (the postgres 10 image is on its way)

As a result, any developper can create a Travis CI account, activate integration for the check_pgactivity repository and then every new commit will be checked like this :

https://travis-ci.org/daamien/check_pgactivity/builds/241807277
