### PR TITLE
[Do not merge] - Pgbouncer services

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ You must provide some mandatory data in the @perfdata array :
 
 * perfdata name
 * the data itself, in numerical form
-* the unit used:'B' for bytes, 's' for secondes or undef for raw numbers
+* the unit used:'B' for bytes, 's' for seconds or undef for raw numbers
 
 The following data are optional :
 
@@ -233,7 +233,7 @@ provides the following hash :
             ORDER BY a.query_start ASC
         }
     );
-``` 
+```
 
 Then, call the query_ver() function, giving the host you want to query, usually
 $host[0], and the %queries hash :
@@ -290,5 +290,3 @@ Use the --debug option to enable the debug output.
 
 Use dprint() function to output some specific debugging messages to the
 developer or the user.
-
-

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -92,97 +92,45 @@ my %services = (
     #    'sub'     => sub reference to call to run this service
     #    'desc'    => 'a description of the service'
     # }
-
+    'archive_folder' => {
+        'sub'  => \&check_archive_folder,
+        'desc' => 'Check archives in given folder.'
+    },
+    'archiver' => {
+        'sub'  => \&check_archiver,
+        'desc' => 'Check the archiver status and number of wal files ready to archive.'
+    },
     'autovacuum' => {
         'sub'  => \&check_autovacuum,
         'desc' => 'Check the autovacuum activity.'
-    },
-    'backends' => {
-        'sub'  => \&check_backends,
-        'desc' => 'Number of connections, compared to max_connections.'
     },
     'backends_status' => {
         'sub'  => \&check_backends_status,
         'desc' => 'Number of connections in relation to their status.'
     },
+    'backends' => {
+        'sub'  => \&check_backends,
+        'desc' => 'Number of connections, compared to max_connections.'
+    },
+    'backup_label_age' => {
+        'sub'  => \&check_backup_label_age,
+        'desc' => 'Check age of backup_label file.'
+    },
+    'bgwriter' => {
+        'sub'  => \&check_bgwriter,
+        'desc' => 'Check the bgwriter activity.'
+    },
+    'btree_bloat' => {
+        'sub'  => \&check_btree_bloat,
+        'desc' => 'Check B-tree index bloat.'
+    },
     'commit_ratio' => {
         'sub'  => \&check_commit_ratio,
         'desc' => 'Commit and rollback rate per second and commit ratio since last execution.'
     },
-    'database_size' => {
-        'sub'  => \&check_database_size,
-        'desc' => 'Variation of database sizes.',
-    },
-    'table_unlogged' => {
-        'sub'  => \&check_table_unlogged,
-        'desc' => 'Check unlogged tables'
-    },
-
-    'wal_files' => {
-        'sub'  => \&check_wal_files,
-        'desc' => 'Total number of WAL files.',
-    },
-    'archiver' => {
-        'sub'  => \&check_archiver,
-        'desc' => 'Check the archiver status and number of wal files ready to archive.',
-    },
-    'last_vacuum' => {
-        'sub'  => \&check_last_vacuum,
-        'desc' =>
-            'Check the oldest vacuum (from autovacuum or not) on the database.',
-    },
-    'last_analyze' => {
-        'sub'  => \&check_last_analyze,
-        'desc' =>
-            'Check the oldest analyze (from autovacuum or not) on the database.',
-    },
-    'locks' => {
-        'sub'  => \&check_locks,
-        'desc' => 'Check the number of locks on the hosts.'
-    },
-    'oldest_2pc' => {
-        'sub'  => \&check_oldest_2pc,
-        'desc' => 'Check the oldest two-phase commit transaction.'
-    },
-    'oldest_idlexact' => {
-        'sub'  => \&check_oldest_idlexact,
-        'desc' => 'Check the oldest idle transaction.'
-    },
-    'longest_query' => {
-        'sub'  => \&check_longest_query,
-        'desc' => 'Check the longest running query.'
-    },
-    'bgwriter' => {
-        'sub'  => \&check_bgwriter,
-        'desc' => 'Check the bgwriter activity.',
-    },
-    'archive_folder' => {
-        'sub'  => \&check_archive_folder,
-        'desc' => 'Check archives in given folder.',
-    },
-    'minor_version' => {
-        'sub'  => \&check_minor_version,
-        'desc' => 'Check if the PostgreSQL minor version is the latest one.',
-    },
-    'hot_standby_delta' => {
-        'sub'  => \&check_hot_standby_delta,
-        'desc' => 'Check delta in bytes between a master and its hot standbys.',
-    },
-    'streaming_delta' => {
-        'sub'  => \&check_streaming_delta,
-        'desc' => 'Check delta in bytes between a master and its standbys in streaming replication.',
-    },
-    'settings' => {
-        'sub'  => \&check_settings,
-        'desc' => 'Check if the configuration file changed.',
-    },
-    'hit_ratio' => {
-        'sub'  => \&check_hit_ratio,
-        'desc' => 'Check hit ratio on databases.'
-    },
-    'backup_label_age' => {
-        'sub'  => \&check_backup_label_age,
-        'desc' => 'Check age of backup_label file.',
+    'configuration' => {
+        'sub'  => \&check_configuration,
+        'desc' => 'Check the most important settings.'
     },
     'connection' => {
         'sub'  => \&check_connection,
@@ -192,65 +140,115 @@ my %services = (
         'sub'  => \&check_custom_query,
         'desc' => 'Perform the given user query.'
     },
-    'configuration' => {
-        'sub'  => \&check_configuration,
-        'desc' => 'Check the most important settings.',
+    'database_size' => {
+        'sub'  => \&check_database_size,
+        'desc' => 'Variation of database sizes.'
     },
-    'btree_bloat' => {
-        'sub'  => \&check_btree_bloat,
-        'desc' => 'Check B-tree index bloat.'
+    'hit_ratio' => {
+        'sub'  => \&check_hit_ratio,
+        'desc' => 'Check hit ratio on databases.'
     },
-    'max_freeze_age' => {
-        'sub'  => \&check_max_freeze_age,
-        'desc' => 'Check oldest database in transaction age.'
+    'hot_standby_delta' => {
+        'sub'  => \&check_hot_standby_delta,
+        'desc' => 'Check delta in bytes between a master and its hot standbys.'
     },
-        'invalid_indexes' => {
+    'invalid_indexes' => {
         'sub'  => \&check_invalid_indexes,
         'desc' => 'Check for invalid indexes.'
-    },
-    'is_master' => {
-        'sub'  => \&check_is_master,
-        'desc' => 'Check if cluster is in production.'
     },
     'is_hot_standby' => {
         'sub'  => \&check_is_hot_standby,
         'desc' => 'Check if cluster is a hot standby.'
     },
-    'pga_version' => {
-        'sub'  => \&check_pga_version,
-        'desc' => 'Check the version of this check_pgactivity script.'
+    'is_master' => {
+        'sub'  => \&check_is_master,
+        'desc' => 'Check if cluster is in production.'
     },
     'is_replay_paused' => {
         'sub'  => \&check_is_replay_paused,
         'desc' => 'Check if the replication is paused.'
     },
-    'table_bloat' => {
-        'sub'  => \&check_table_bloat,
-        'desc' => 'Check tables bloat.'
+    'last_analyze' => {
+        'sub'  => \&check_last_analyze,
+        'desc' =>
+            'Check the oldest analyze (from autovacuum or not) on the database.'
     },
-    'temp_files' => {
-        'sub'  => \&check_temp_files,
-        'desc' => 'Check temp files generation'
+    'last_vacuum' => {
+        'sub'  => \&check_last_vacuum,
+        'desc' =>
+            'Check the oldest vacuum (from autovacuum or not) on the database.'
     },
-    'replication_slots' => {
-        'sub'  => \&check_replication_slots,
-        'desc' => 'Check delta in bytes of the replication slots.'
+    'locks' => {
+        'sub'  => \&check_locks,
+        'desc' => 'Check the number of locks on the hosts.'
+    },
+    'longest_query' => {
+        'sub'  => \&check_longest_query,
+        'desc' => 'Check the longest running query.'
+    },
+    'minor_version' => {
+        'sub'  => \&check_minor_version,
+        'desc' => 'Check if the PostgreSQL minor version is the latest one.'
+    },
+    'oldest_2pc' => {
+        'sub'  => \&check_oldest_2pc,
+        'desc' => 'Check the oldest two-phase commit transaction.'
+    },
+    'oldest_idlexact' => {
+        'sub'  => \&check_oldest_idlexact,
+        'desc' => 'Check the oldest idle transaction.'
+    },
+    'max_freeze_age' => {
+        'sub'  => \&check_max_freeze_age,
+        'desc' => 'Check oldest database in transaction age.'
     },
     'pg_dump_backup' => {
         'sub'  => \&check_pg_dump_backup,
         'desc' => 'Check pg_dump backups age and retention policy'
     },
-    'stat_snapshot_age' => {
-        'sub'  => \&check_stat_snapshot_age,
-        'desc' => 'Check stats collector\'s stats age'
+    'pga_version' => {
+        'sub'  => \&check_pga_version,
+        'desc' => 'Check the version of this check_pgactivity script.'
+    },
+    'pgdata_permission' => {
+        'sub'  => \&check_pgdata_permission,
+        'desc' => 'Check that the permission on PGDATA is 700'
+    },
+    'replication_slots' => {
+        'sub'  => \&check_replication_slots,
+        'desc' => 'Check delta in bytes of the replication slots.'
     },
     'sequences_exhausted' => {
         'sub'  => \&check_sequences_exhausted,
         'desc' => 'Check that auto-incremented colums aren\'t reaching their upper limit'
     },
-    'pgdata_permission' => {
-        'sub'  => \&check_pgdata_permission,
-        'desc' => 'Check that the permission on PGDATA is 700'
+    'settings' => {
+        'sub'  => \&check_settings,
+        'desc' => 'Check if the configuration file changed.'
+    },
+    'stat_snapshot_age' => {
+        'sub'  => \&check_stat_snapshot_age,
+        'desc' => 'Check stats collector\'s stats age'
+    },
+    'streaming_delta' => {
+        'sub'  => \&check_streaming_delta,
+        'desc' => 'Check delta in bytes between a master and its standbys in streaming replication.'
+    },
+    'table_bloat' => {
+        'sub'  => \&check_table_bloat,
+        'desc' => 'Check tables bloat.'
+    },
+    'table_unlogged' => {
+        'sub'  => \&check_table_unlogged,
+        'desc' => 'Check unlogged tables'
+    },
+    'temp_files' => {
+        'sub'  => \&check_temp_files,
+        'desc' => 'Check temp files generation'
+    },
+    'wal_files' => {
+        'sub'  => \&check_wal_files,
+        'desc' => 'Total number of WAL files.'
     }
 );
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -210,6 +210,22 @@ my %services = (
         'sub'  => \&check_pga_version,
         'desc' => 'Check the version of this check_pgactivity script.'
     },
+    'pgbouncer_databases' => {
+        'sub'  => \&check_pgb_databases,
+        'desc' => 'Number of connections, compared to database max_connections.'
+    },
+    'pgbouncer_databases_reserve_pool' => {
+        'sub'  => \&check_pgb_databases_reserve_pool,
+        'desc' => 'Check if connections are close to pool_size + reserve_pool.'
+    },
+    'pgbouncer_stats' => {
+        'sub'  => \&check_pgb_stats,
+        'desc' => 'Collect pgbouncer stats.'
+    },
+    'pgbouncer_waiting_clients' => {
+        'sub'  => \&check_pgb_waiting_clients,
+        'desc' => 'Check if client are waiting (when pool_mode=session).'
+    },
     'pgdata_permission' => {
         'sub'  => \&check_pgdata_permission,
         'desc' => 'Check that the permission on PGDATA is 700'
@@ -5427,6 +5443,386 @@ sub check_pga_version {
 
     return ok( $me, [ sprintf($msg, "", $^V) ] );
 }
+
+=item B<pgbouncer_databases>
+
+Check the number of connections for each pgbouncer database.
+
+Perfdata contains the number of connections per database.
+
+Critical and Warning thresholds accept either a raw number or a percentage (eg.
+80%). When a threshold is a percentage, it is computed according
+to max_db_connections.
+
+=cut
+sub check_pgb_databases {
+    my $me        = 'POSTGRES_CHECK_PGBOUNCER_DATABASES';
+    my %args      = %{ $_[0] };
+    my @perfdata;
+    my @msg;
+    my @msg_crit;
+    my @msg_warn;
+    my @longmsg;
+    my @hosts;
+    my $query;
+    my @rs;
+    my $warn_threshold;
+    my $crit_threshold;
+
+    # TODO : handle exclude/include
+
+    # warning and critical are mandatory.
+    pod2usage(
+        -message => "FATAL: you must specify critical and warning thresholds.",
+        -exitval => 127
+    ) unless defined $args{'warning'} and defined $args{'critical'} ;
+
+    # warning and critical must be raw or %.
+    pod2usage(
+        -message => "FATAL: critical and warning thresholds only accept raw numbers or %.",
+        -exitval => 127
+    ) unless $args{'warning'}  =~ m/^([0-9.]+)%?$/
+        and  $args{'critical'} =~ m/^([0-9.]+)%?$/;
+
+    @hosts = @{ parse_hosts %args };
+
+    pod2usage(
+        -message => 'FATAL: you must give only one host with service "pgbouncer_backends".',
+        -exitval => 127
+    ) if @hosts != 1;
+
+    # Get pgbouncer configuration per database
+    $query = q{
+        SHOW DATABASES
+    };
+    @rs = @{ query( $hosts[0], $query ) };
+
+    foreach my $r ( @rs) {
+      # pgbdatabasename     : $r->[0]
+      # max_connections     : $r->[8]
+      # current_connections : $r->[9]
+
+      # ignore pseudo database pgbouncer
+      next if ($r->[0] eq "pgbouncer");
+
+      if ($args{'warning'} =~ /^([0-9.]+)%$/) {
+        $warn_threshold = $r->[8] - int( $r->[8] * $1 / 100 );
+      }
+      else {
+        $warn_threshold = $r->[8] - $args{'warning'};
+      }
+
+      if ($args{'critical'} =~ /^([0-9.]+)%$/) {
+        $crit_threshold = $r->[8] - int( $r->[8] * $1 / 100 );
+      }
+      else {
+        $crit_threshold = $r->[8] - $args{'critical'};
+      }
+
+      push @perfdata , (
+          ["$r->[0]_current_connections", $r->[9], undef,
+          $warn_threshold, $crit_threshold,
+          0,$r->[8]]
+          );
+
+      # Check if max_db_connection is reached. Unlimited if max_connections = 0
+      if ($r->[9] >= $crit_threshold && $r->[8] > 0) {
+        push @msg_crit, "pgbouncer $r->[0] too many connexions";
+        push @longmsg, "$r->[0] connections: $r->[9] >="
+              ." $crit_threshold crit threshold";
+      }
+      elsif ($r->[9] >= $warn_threshold && $r->[8] > 0) {
+        push @msg_warn, "pgbouncer $r->[0] too many connexions";
+        push @longmsg, "$r->[0] connections: $r->[9] >="
+              ." $warn_threshold warn threshold";
+      }
+    }
+
+    return critical( $me, [ @msg_crit, @msg_warn ], \@perfdata, \@longmsg )
+        if @msg_crit > 0;
+    return warning( $me, \@msg_warn, \@perfdata, \@longmsg ) if @msg_warn > 0;
+    return ok( $me, \@msg, \@perfdata, \@longmsg );
+}
+
+=item B<pgbouncer_databases_reserve_pool>
+
+Check the number of connections for each pgbouncer pool. It should be used for
+session pooling in order to warn if connections are used from reserve_pool.
+
+Perfdata contains the number of active clients per pool.
+
+Critical and Warning thresholds accept either a raw number or a percentage (eg.
+80%). When a threshold is a percentage, it is computed according
+to pool_size and reserve_pool.
+
+=cut
+sub check_pgb_databases_reserve_pool {
+    my $me        = 'POSTGRES_CHECK_PGBOUNCER_DATABASES_RESERVE_POOL';
+    my %args      = %{ $_[0] };
+    my @perfdata;
+    my @msg;
+    my @msg_crit;
+    my @msg_warn;
+    my @longmsg;
+    my @hosts;
+    my $query;
+    my @databases;
+    my @rs;
+    my $warn_threshold;
+    my $crit_threshold;
+
+    # TODO : handle exclude/include
+
+
+    # warning and critical are mandatory.
+    pod2usage(
+        -message => "FATAL: you must specify critical and warning thresholds.",
+        -exitval => 127
+    ) unless defined $args{'warning'} and defined $args{'critical'} ;
+
+    # warning and critical must be raw or %.
+    pod2usage(
+        -message => "FATAL: critical and warning thresholds only accept raw numbers or %.",
+        -exitval => 127
+    ) unless $args{'warning'}  =~ m/^([0-9.]+)%?$/
+        and  $args{'critical'} =~ m/^([0-9.]+)%?$/;
+
+    @hosts = @{ parse_hosts %args };
+
+    pod2usage(
+        -message => 'FATAL: you must give only one host with service "pgbouncer_backends".',
+        -exitval => 127
+    ) if @hosts != 1;
+
+    # Get pgbouncer configuration per database
+    $query = q{
+        SHOW DATABASES
+    };
+    @databases = @{ query( $hosts[0], $query ) };
+
+    # Get pgbouncer pools statistics
+    $query = q{
+        SHOW POOLS
+    };
+    @rs = @{ query( $hosts[0], $query ) };
+
+    foreach my $r ( @rs) {
+      # pgbdatabasename      : $r->[0]
+      # user                 : $r->[1]
+      # cl_active            : $r->[2]
+      # cl_waiting           : $r->[3]
+      # sv_active            : $r->[4]
+      # sv_idle              : $r->[5]
+      # sv_used              : $r->[6]
+      # sv_tested            : $r->[7]
+      # sv_login             : $r->[8]
+      # maxwait              : $r->[9]
+      # pool_mode            : $r->[10]
+      # pool_size            : $r->[11]
+      # reserve_pool         : $r->[12]
+      # warning threshold    : $r->[13]
+      # critical threshold   : $r->[14]
+
+      # ignore pseudo pool pgbouncer
+      next if ($r->[0] eq "pgbouncer");
+
+      # ignore if pool_mode is not session
+      next if ($r->[10] ne "session");
+
+      # nested loop to push news columns to pools array which contain pool_size
+      # and reserve slot
+      foreach my $database ( @databases) {
+        # pgbdatabasename  : $database->[0]
+        # pool_size        : $database->[5]
+        # reserve_pool     : $database->[6]
+
+        push @$r, $database->[5] if ($database->[0] eq $r->[0]);
+        push @$r, $database->[6] if ($database->[0] eq $r->[0]);
+      }
+
+      # check if pool_size is defined, sometimes, pgbouncer cleans "SHOW DATABASES"
+      # view and the join with "SHOW POOLS" is not consistent.
+      if ( defined $r->[11]) {
+        if ($args{'warning'} =~ /^([0-9.]+)%$/) {
+          $warn_threshold = $r->[11] + $r->[12] - int( $r->[12] * $1 / 100 );
+        }
+        else {
+          $warn_threshold = $r->[11] + $r->[12] - $args{'warning'};
+        }
+
+        if ($args{'critical'} =~ /^([0-9.]+)%$/) {
+          $crit_threshold = $r->[11] + $r->[12] - int( $r->[12] * $1 / 100 );
+        }
+        else {
+          $crit_threshold = $r->[11] + $r->[12] - $args{'critical'};
+        }
+
+        push @perfdata, (
+            ["$r->[0]/$r->[1]_cl_active",$r->[2],undef,
+            $warn_threshold,$crit_threshold,
+            0,$r->[11]+$r->[12]]
+            );
+
+        # Check if connections are close to pool_size+reserve_pool
+        if ($r->[2] >= $crit_threshold) {
+          push @msg_crit, "pgbouncer $r->[0]/$r->[1] too many connexions";
+          push @longmsg, "$r->[0]/$r->[1] connections: $r->[2] >="
+                ." $crit_threshold crit threshold";
+        }
+        elsif ($r->[2] >= $warn_threshold) {
+          push @msg_warn, "pgbouncer $r->[0]/$r->[1] too many connexions";
+          push @longmsg, "$r->[0]/$r->[1] connections: $r->[2] >="
+                ." $warn_threshold warn threshold";
+        }
+      }
+    }
+
+    return critical( $me, [ @msg_crit, @msg_warn ], \@perfdata, \@longmsg )
+        if @msg_crit > 0;
+    return warning( $me, \@msg_warn, \@perfdata, \@longmsg ) if @msg_warn > 0;
+    return ok( $me, \@msg, \@perfdata, \@longmsg );
+}
+
+=item B<pgbouncer_waiting_clients>
+
+Check the number of waiting clients for each pgbouncer pool.
+
+Perfdata contains :
+  * the number of active and waiting clients per pool.
+  * the number of active, idle, used, tested, login servers per pool.
+  * The maxwait time per pool.
+
+Critical and Warning thresholds accept a raw number.
+
+=cut
+sub check_pgb_waiting_clients {
+    my $me        = 'POSTGRES_CHECK_WAITING_CLIENTS';
+    my %args      = %{ $_[0] };
+    my @perfdata;
+    my @msg;
+    my @msg_crit;
+    my @msg_warn;
+    my @longmsg;
+    my @hosts;
+    my $query;
+    my @rs;
+
+    $args{'warning'}  = 1 if not ( defined $args{'warning'} );
+    $args{'critical'} = 2 if not ( defined $args{'critical'} );
+
+    # TODO : handle exclude/include
+
+
+    # warning and critical must be raw
+    pod2usage(
+        -message => "FATAL: critical and warning thresholds only accept raw numbers.",
+        -exitval => 127
+    ) if defined $args{'critical'} and $args{'warning'} !~ m/^([0-9]+)$/
+        and  $args{'critical'} !~ m/^([0-9]+)$/;
+
+    @hosts = @{ parse_hosts %args };
+
+    pod2usage(
+        -message => 'FATAL: you must give only one host with service "pgbouncer_backends".',
+        -exitval => 127
+    ) if @hosts != 1;
+
+    # Get pgbouncer pools statistics
+    $query = q{
+        SHOW POOLS
+    };
+    @rs = @{ query( $hosts[0], $query ) };
+
+    foreach my $r ( @rs) {
+      # pgbdatabasename  : $r->[0]
+      # user             : $r->[1]
+      # cl_active        : $r->[2]
+      # cl_waiting       : $r->[3]
+      # sv_active        : $r->[4]
+      # sv_idle          : $r->[5]
+      # sv_used          : $r->[6]
+      # sv_tested        : $r->[7]
+      # sv_login         : $r->[8]
+      # maxwait          : $r->[9]
+
+      # ignore pseudo pool pgbouncer
+      next if ($r->[0] eq "pgbouncer");
+
+      push @perfdata, (
+          ["$r->[0]/$r->[1]_cl_active", $r->[2], undef, undef, undef,0],
+          ["$r->[0]/$r->[1]_cl_waiting", $r->[3], undef,
+            $args{'warning'}, $args{'critical'},0],
+          ["$r->[0]/$r->[1]_sv_active", $r->[4], undef, undef, undef,0],
+          ["$r->[0]/$r->[1]_sv_idle", $r->[5], undef, undef, undef,0],
+          ["$r->[0]/$r->[1]_sv_used", $r->[6], undef, undef, undef,0],
+          ["$r->[0]/$r->[1]_sv_tested", $r->[7], undef, undef, undef,0],
+          ["$r->[0]/$r->[1]_sv_login", $r->[8], undef, undef, undef,0],
+          ["$r->[0]/$r->[1]_maxwait", $r->[9], "s", undef, undef,0]
+          );
+
+      # Check if client connection are waiting
+      if ($r->[3] >= $args{'critical'} && $r->[3] > 0) {
+        push @msg_crit, "Waiting clients on $r->[0]/$r->[1]";
+        push @longmsg, "$r->[3] waiting clients on $r->[0]/$r->[1]";
+
+      }
+      elsif ($r->[3] >= $args{'warning'} && $r->[3] > 0) {
+        push @msg_warn, "Waiting clients on $r->[0]/$r->[1]";
+        push @longmsg, "$r->[3] waiting clients on $r->[0]/$r->[1]";
+      }
+
+    }
+
+    return critical( $me, [ @msg_crit, @msg_warn ], \@perfdata, \@longmsg )
+        if @msg_crit > 0;
+    return warning( $me, \@msg_warn, \@perfdata, \@longmsg ) if @msg_warn > 0;
+    return ok( $me, \@msg, \@perfdata, \@longmsg );
+}
+
+=item B<pgbouncer_stats>
+
+Report pgbouncer statistics.
+
+=cut
+sub check_pgb_stats {
+    my $me        = 'POSTGRES_CHECK_PGBOUNCER_STATS';
+    my %args      = %{ $_[0] };
+    my @perfdata;
+    my @hosts;
+    my $query;
+    my @rs;
+
+    @hosts = @{ parse_hosts %args };
+
+    pod2usage(
+        -message => 'FATAL: you must give only one host with service "pgbouncer_backends".',
+        -exitval => 127
+    ) if @hosts != 1;
+
+    # Get pgbouncer stats
+    $query = q{
+        SHOW STATS
+    };
+    @rs = @{ query( $hosts[0], $query ) };
+
+    foreach my $r ( @rs) {
+      # pgbdatabasename  : $r->[0]
+      # avg_req          : $r->[5]
+      # avg_recv         : $r->[6]
+      # avg_sent         : $r->[7]
+      # avg_query        : $r->[8]
+
+      push @perfdata, (
+          ["$r->[0]_avg_req", $r->[5], undef,undef,undef,0],
+          ["$r->[0]_avg_recv", $r->[6], "B",undef,undef,0],
+          ["$r->[0]_avg_sent", $r->[7], "B",undef,undef,0],
+          ["$r->[0]_avg_query", $r->[8], "us",undef,undef,0]
+          );
+    }
+
+    return ok( $me, [ "Pgbouncer stats" ], \@perfdata );
+}
+
 
 =item B<pgdata_permission> (8.2+)
 


### PR DESCRIPTION
This PR should address #106 and other things (typo, sort services).

TODO : 

  * [x] : Doc
  * [x] : Pgbouncer stats service (just to collect stats)
  * [x] : handle when max_db_connection is not present in database section (pgbouncer use max_db_connection from default config). We must join with SHOW CONFIG
  * [x] : sometime pgbouncer clean database from show database. If we join with show pools, result is not consistent. pool are present but databases are missing.

Feature request : 

  * [x] : output without perfdata : some services provide serveral perfdata per pool or database. It generates plenty perfdatas when the cluster has hundred databases. https://github.com/OPMDG/check_pgactivity/issues/156