### PR TITLE
Avoid warning for 2.4dev (service check_pga_version)

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5416,8 +5416,8 @@ sub check_pga_version {
     pod2usage(
         -message => "FATAL: given version does not look like a check_pgactivity version!",
         -exitval => 127
-    ) if ( defined $args{'critical'} and $args{'critical'} !~ m/^\d\.\d+(?:_?(?:beta|rc)\d*)?$/ )
-        or (defined $args{'warning'} and $args{'warning'} !~ m/^\d\.\d+(?:_?(?:beta|rc)\d*)?$/ );
+    ) if ( defined $args{'critical'} and $args{'critical'} !~ m/^\d\.\d+(?:_?(?:dev|beta|rc)\d*)?$/ )
+        or (defined $args{'warning'} and $args{'warning'} !~ m/^\d\.\d+(?:_?(?:dev|beta|rc)\d*)?$/ );
 
     return critical( $me,
         [ sprintf($msg, "(should be $args{'critical'}!)", $^V) ]


### PR DESCRIPTION
check_pgactivity --service check_pga_version: avoid a warning when testing testing 2.4dev
