### PR TITLE
Fix is_replay_paused for PostgreSQL 10

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -3987,7 +3987,7 @@ sub check_is_replay_paused {
             ELSE NULL::int
         END AS lag,
         CASE
-            WHEN pg_is_in_recovery() AND pg_last_wal_replay_location() <> pg_last_wal_receive_location()
+            WHEN pg_is_in_recovery() AND pg_last_wal_replay_lsn() <> pg_last_wal_receive_lsn()
                 THEN 1::int
             WHEN pg_is_in_recovery() THEN 0::int
             ELSE NULL


### PR DESCRIPTION
It seems that we missed the rename of location to lsn for this one.