### PR TITLE
Ignore startup and backup replication states in service streaming_delta

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -6117,15 +6117,18 @@ sub check_streaming_delta {
         $PG_VERSION_100 => q{SELECT application_name, client_addr, pid,
             sent_lsn, write_lsn, flush_lsn, replay_lsn,
             CASE pg_is_in_recovery() WHEN true THEN pg_last_wal_receive_lsn() ELSE pg_current_wal_lsn() END
-            FROM pg_stat_replication},
+            FROM pg_stat_replication
+	    WHERE state NOT IN ('startup', 'backup')},
         $PG_VERSION_92 => q{SELECT application_name, client_addr, pid,
             sent_location, write_location, flush_location, replay_location,
             CASE pg_is_in_recovery() WHEN true THEN pg_last_xlog_receive_location() ELSE pg_current_xlog_location() END
-            FROM pg_stat_replication},
+            FROM pg_stat_replication
+	    WHERE state NOT IN ('startup', 'backup')},
         $PG_VERSION_91 => q{SELECT application_name, client_addr, procpid,
             sent_location, write_location, flush_location, replay_location,
             CASE pg_is_in_recovery() WHEN true THEN pg_last_xlog_receive_location() ELSE pg_current_xlog_location() END
-            FROM pg_stat_replication}
+            FROM pg_stat_replication
+	    WHERE state NOT IN ('startup', 'backup')}
     );
     # FIXME this service should check for given slaves in opts!
 


### PR DESCRIPTION
In case we encounter the startup state, we'll encounter 0/0 as current replication LSN,
meaning that we might a lag of hundreds of giga-bytes or tera-bytes.

Ignore such behavior but filtering out the startup state, as well as the backup state.