### PR TITLE
set correct version for wal magic number in version 10

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -1423,7 +1423,7 @@ sub check_archive_folder {
         '94' => 53374,
         '95' => 53383,
         '96' => 53395,
-        '100' => 53397
+        '100' => 53399
     );
 
     # "path" argument must be given


### PR DESCRIPTION
WAL version in PostgreSQL code is : 
   * 0xD093 in version 9.6
   * 0xD097 in version 10

Thus in the check_pgactivity code : 
  * 53395 in version 9.6
  * 53399 in version 10