### PR TITLE
Fix wal_files: wal_keep_segments forgotten in v10

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -7340,7 +7340,8 @@ sub check_wal_files {
           WHERE name IN ('max_wal_size','wal_segment_size','wal_block_size','wal_keep_segments')
         )
         SELECT s.name,
-          max_wal_size / (wal_block_size * wal_segment_size / 1024^2) max_nb_wal,
+          wal_keep_segments
+           + (max_wal_size / (wal_block_size * wal_segment_size / 1024^2)) AS max_nb_wal,
           CASE WHEN pg_is_in_recovery()
             THEN NULL
             ELSE pg_current_wal_lsn()
@@ -7453,7 +7454,7 @@ sub check_wal_files {
     @rs = @{ query_ver( $hosts[0], %queries ) };
 
     $first_seg = $rs[0][0];
-    $max_segs  = $rs[0][1];
+    $max_segs  = $rs[0][1]; #segments to keep including kept segments
     $tli = hex($rs[0][4]);
 
     foreach my $r (@rs) {
@@ -7471,7 +7472,7 @@ sub check_wal_files {
     if ( $hosts[0]{'version_num'} >= $PG_VERSION_90) {
         $seg_kept = $rs[0][3];
         if ($seg_kept > 0) {
-            # cheet with numbers if the keep_segment was just set and the
+            # cheat with numbers if the keep_segment was just set and the
             # number of wal doesn't match it yet.
             if ($seg_kept > $seg_written) {
                 push @perfdata => [ "written_wal", 1 ];


### PR DESCRIPTION
Add wal_keep_segments when computing the max number of wal files to keep in v10.

See https://github.com/OPMDG/check_pgactivity/issues/194

(Bonus: a typo, a comment)