### PR TITLE
Release 2.4 and other fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 Changelog
 =========
 
+2018-18-XX v2.4:
+
+  - fix handling or file reading errors in archive_folder service
+  - fix wal magic number for version 10
+  - fix service stat_snapshot_age to output the correct age
+  - fix archiver and replication_slots services to work properly on a standby node
+  - fix is_replay_paused for PostgreSQL 10
+  - fix max_nb_wal calculation in wal_files service
+  - fix uninitialized bug in hit_ratio when database do not yet have statistics
+  - fix check_backend_status in order to ignore unknown status
+  - fix service sequences_exhausted to take account of sequence's minvalue
+  - fix sequences_exhausted to take account of sequences only in the current db
+  - fix exclude option in backends_status service
+  - ignore startup and backup replication states in service streaming_delta
+  - avoid warning for -dev versions in pga_version service
+  - add a new uptime service
+  - replication_slots service handle wal files and pg_replslots files separately
+  - add ability to filter by application_name in longest_query and oldest_xact service
+  - add minimal delta size to pgdump_backup service to avoid alert when backup grows small in size
+  - add documentation example for pgback in pgdump_service
+  - add documentation for archive_folder
+  - add privileges information for all services
+  - take account of the new BRIN summarize state of autovacuum
+
 2017-11-13 v2.3:
   - add complete support for PostgreSQL 10, including non-privileged monitoring
     features

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -3024,7 +3024,7 @@ sub check_commit_ratio {
     };
 
     if ( defined $args{'warning'} ) {
-        my $thresholds_re = qr/(rollbacks|rollback_rate|rollback_ratio)\s*=\s*(\d+)/i;
+        my $thresholds_re = qr/(rollbacks|rollback_rate|rollback_ratio)\s*=\s*([0-9]+\.?[0-9]*)/i;
 
         # warning and critical must be list of status=value
         pod2usage(

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5666,6 +5666,11 @@ Required privileges:
  v10: unprivileged role, or superuser to monitor logical replication
  v11: unpriviledged user with GRANT EXECUTE on function pg_ls_dir(text)
 
+Here is an example:
+
+    -w 'wal=50,replslot=20' -c 'wal=100,replslot=40'
+
+
 =cut
 
 sub check_replication_slots {

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -3024,7 +3024,7 @@ sub check_commit_ratio {
     };
 
     if ( defined $args{'warning'} ) {
-        my $thresholds_re = qr/(rollbacks|rollback_rate|rollback_ratio)\s*=\s*([0-9]+\.?[0-9]*)/i;
+        my $thresholds_re = qr/(rollbacks|rollback_rate|rollback_ratio)\s*=\s*(\d+)/i;
 
         # warning and critical must be list of status=value
         pod2usage(


### PR DESCRIPTION
Hi,

This PR contains:
- An example for replication_slot service
- A change for commit_ratio threshold from integer type to float. It may be useful when rollback_ratio is low (less than 1%), you can specify `rollback_ratio=0.1` for 0.1% rollback ratio.
- CHANGELOG.md updated for 2.4 release

I you prefer I can split this PR in separate PR for CHANGELOG.md vs other commits.

Regards,