### PR TITLE
Allow psql connections without any connection parameters given

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -270,7 +270,15 @@ list.
 
 =item B<-h>, B<--host> HOST
 
-Database server host or socket directory (default: "localhost").
+Note: if neither host, username, port or database is given, psql will
+be invoked without any of those parameters passed over.  psql will
+then typically try to connect to the default unix socket (typically
+/var/run/postgresql/.s.PGSQL.5432) using the unix username as the
+database username and database, typically using the ident
+authentication.  If one or more of the above mentioned parameters are
+given but not all, the defaults will apply to the rest.
+
+Database server host or socket directory (default: "localhost")
 
 =item B<-U>, B<--username> ROLE
 
@@ -514,9 +522,10 @@ sub save($$$$) {
 
     if (defined $host->{'dbservice'}) {
         $hostkey = "$host->{'dbservice'}";
-    }
-    else {
+    } elsif (defined $host->{'host'}) {
         $hostkey = "$host->{'host'}$host->{'port'}";
+    } else {
+	$hostkey = "localhost/default"
     }
 
     die "File «${storage}» not recognized as a check_pgactivity status file.\n\n"
@@ -547,9 +556,10 @@ sub load($$$) {
 
     if (defined $host->{'dbservice'}) {
         $hostkey = "$host->{'dbservice'}";
-    }
-    else {
+    } elsif (defined $host->{'host'}) {
         $hostkey = "$host->{'host'}$host->{'port'}";
+    } else {
+	$hostkey = "localhost/default"
     }
 
     return undef unless -r $storage;
@@ -886,6 +896,10 @@ sub parse_hosts(\%) {
                 $hosts[-1]{'host'}, $hosts[-1]{'port'}, $hosts[-1]{'db'}
             );
         }
+    }
+
+    if (!@hosts) {
+	push(@hosts, {'name' => 'localhost/default'});
     }
 
     dprint ('Hosts: '. Dumper(\@hosts));

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -494,6 +494,24 @@ sub is_storable($) {
     return defined Storable::read_magic($head);
 }
 
+# Find a unique string for the database instance connection.
+# Used by save and load.
+#
+# Parameter: host structure ref that holds the "hsot" and "port" parameters
+sub find_hostkey($) {
+    my $hostkey;
+    my $host = shift;
+    if (defined $host->{'dbservice'}) {
+        $hostkey = "$host->{'dbservice'}";
+    } elsif (defined $host->{'host'}) {
+        $hostkey = "$host->{'host'}$host->{'port'}";
+    } else {
+	## no connection parameters defined, using psql defaults
+	$hostkey = "localhost/default"
+    }
+    return $hostkey;
+}
+
 # Record the given ref content for the given host in a file on disk.
 # The file is defined by argument "--status-file" on command line. By default:
 #
@@ -518,15 +536,8 @@ sub save($$$$) {
     my $ref     = shift;
     my $storage = shift;
     my $all     = {};
-    my $hostkey;
+    my $hostkey = find_hostkey($host);
 
-    if (defined $host->{'dbservice'}) {
-        $hostkey = "$host->{'dbservice'}";
-    } elsif (defined $host->{'host'}) {
-        $hostkey = "$host->{'host'}$host->{'port'}";
-    } else {
-	$hostkey = "localhost/default"
-    }
 
     die "File «${storage}» not recognized as a check_pgactivity status file.\n\n"
         ."Please, check its path or move away this wrong file"
@@ -551,16 +562,8 @@ sub load($$$) {
     my $host    = shift;
     my $name    = shift;
     my $storage = shift;
-    my $hostkey;
+    my $hostkey = find_hostkey($host);
     my $all;
-
-    if (defined $host->{'dbservice'}) {
-        $hostkey = "$host->{'dbservice'}";
-    } elsif (defined $host->{'host'}) {
-        $hostkey = "$host->{'host'}$host->{'port'}";
-    } else {
-	$hostkey = "localhost/default"
-    }
 
     return undef unless -r $storage;
 
@@ -899,6 +902,12 @@ sub parse_hosts(\%) {
     }
 
     if (!@hosts) {
+	## No connection parameters given; we'll push an empty host
+	## with the hostkey/name "localhost/default".  With no other
+	## keys in the hash, no connection parameters will be passed
+	## to psql, and it will most likely connect to localhost using
+	## the unix domain socket in the default path and with a
+	## filename containing the default port number.
 	push(@hosts, {'name' => 'localhost/default'});
     }
 


### PR DESCRIPTION
Re issue #94 and earlier pull request #96, a new attempt on a pull request, rebased on the master, and with improved inline documentation.

Prior to this commit, if no connection parameters were given, one
would get errors like:

   FATAL: you must give only one host with service "XXX"

At the other hand, if at least one connection parameter was given,
any connection parameter omitted would cause other parameters to
be set to default.

After this commit, if no connection parameters are given, psql will be started up without any parameters, this will typically cause it to try to connect to the database using the default unix socket file in the default unix socket dir, typically /var/run/postgresql/.s.PGSQL.5432 (but may vary depending on distribution/compile-time options), with the same database username as unix username and same database name as unix username.

For backward compatibility (and to keep a minimal changeset), if any connection parameters are given, any omitted connection parameters will receive the default values as defined in the script.  This is arguably inconsistent, but I still believe this is the best option.

If you do believe consistency is more important than backward compatibility, I will rewrite the host parsing and psql connection so that the host will be omitted rather than defaulted to "localhost" when calling on psql.