### PR TITLE
Ugly hack to fix regression in pgdata_permission

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5694,13 +5694,18 @@ sub check_pgdata_permission {
         my $pg_line_uid;
         my @rs_tmp;
 
-        $query = qq{
+        # first query is a ugly hack to bypass query() control about number of
+        # columns expected.
+        $query = qq{ select ' ';
             select pg_backend_pid() as pid
             \\gset
             \\setenv PID :pid
             \\! cat /proc/\$PID/status
         };
         @rs = @{ query ( $hosts[0], $query ) };
+
+        # takes part of the ugly hack to bypass query() control.
+        shift @rs;
 
         # As the usual separators are not there, we only get a big record
         # separated with \n


### PR DESCRIPTION
Service pgdata_permission is broken since commit
82158b3ba242aa7bbc0cbcb4217444dd6bd61b44

This commit expects the first row to be the columns names and removes it from
final result. However, pgdata_permission doesn't expect query result, but
system command output using psql command \!, without header. So the system
command dresult was in fact removed as the header part, leaving no data to
parse to the pgdata_permission service...

If #155 is fixed at some point, don't forget to clean this on the way.