### PR TITLE
Fix archiver comments: needs superuser right again because of pg_stat_file

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -1695,7 +1695,7 @@ waiting to be archived. They only accept a raw number of files.
 Whatever the given threshold, a critical alert is raised if the archiver
 process did not archive the oldest waiting WAL to be archived since last call.
 
-Required privileges: unprivileged role (10+); superuser (<10).
+Required privileges: superuser.
 
 =cut
 


### PR DESCRIPTION
Forgotten in #237 

In fact, execute on pg_stat_file(text) in the connection DB is enough, do we need to add this level of detail?