### PR TITLE
Add a new oldest_xmin check.

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -426,6 +426,7 @@ my %args = (
     'port'                  => undef,
     'dbname'                => undef,
     'dbservice'             => undef,
+    'detailed'              => 0,
     'warning'               => undef,
     'critical'              => undef,
     'exclude'               => [],
@@ -5740,8 +5741,10 @@ sub check_oldest_xmin {
     my @msg_crit;
     my @msg_warn;
     my @hosts;
+    my $detailed;
     my $c_limit;
     my $w_limit;
+    my %oldest_xmin; # track oldest xmin and its kind for each database
     my %args      = %{ $_[0] };
     my $me        = 'POSTGRES_OLDEST_XMIN';
     my @dbinclude = @{ $args{'dbinclude'} };
@@ -5858,8 +5861,9 @@ sub check_oldest_xmin {
     ) unless $args{'warning'}  =~ m/^([0-9.]+)$/
         and  $args{'critical'} =~ m/^([0-9.]+)$/;
 
-    $c_limit = $args{'critical'};
-    $w_limit = $args{'warning'};
+    $detailed = $args{'detailed'};
+    $c_limit  = $args{'critical'};
+    $w_limit  = $args{'warning'};
 
     @hosts = @{ parse_hosts %args };
 
@@ -5879,10 +5883,23 @@ sub check_oldest_xmin {
 
         map { $_ = 'NaN' if $_ eq ''} @{$r}[2..3];
 
-        push @perfdata => (
-            ["$r->[0]_$r->[1]_age", $r->[2]],
-            ["$r->[0]_$r->[1]_xmin", $r->[3]]
-        );
+        if ($detailed) {
+            push @perfdata => (
+                ["$r->[0]_$r->[1]_age", $r->[2]],
+                ["$r->[0]_$r->[1]_xmin", $r->[3]]
+            );
+        }
+        else {
+            if ( exists $oldest_xmin{$r->[0]} ) {
+                $oldest_xmin{$r->[0]} = [ $r->[1], $r->[2] ]
+                    if $oldest_xmin{$r->[0]}[1] eq 'NaN'
+                    or $r->[2] > $oldest_xmin{$r->[0]}[1];
+            }
+            else {
+                $oldest_xmin{$r->[0]} = [ $r->[1], $r->[2] ];
+            }
+        }
+
         if (defined $c_limit) {
             if ($r->[2] ne 'NaN' and $r->[2] > $c_limit) {
                 push @msg_crit => "$r->[0]_$r->[1]_age";
@@ -5894,13 +5911,25 @@ sub check_oldest_xmin {
         }
     }
 
+    if (not $detailed) {
+        foreach my $k (keys %oldest_xmin) {
+            push @perfdata => (
+                ["${k}_age", $oldest_xmin{$k}[1]]
+            );
+
+            push @msg, "Oldest xmin in $k from ". $oldest_xmin{$k}[0]
+                if $oldest_xmin{$k}[1] ne 'NaN';
+        }
+    }
+
     return status_critical( $me, [
         'Critical: '. join(',', @msg_crit)
-        . (scalar @msg_warn? ' Warning: '. join(',', @msg_warn):'')
+        . (scalar @msg_warn? ' Warning: '. join(',', @msg_warn):''),
+        @msg
     ], \@perfdata ) if scalar @msg_crit;
 
     return status_warning( $me,
-        [ 'Warning: '. join(',', @msg_warn) ], \@perfdata
+        [ 'Warning: '. join(',', @msg_warn), @msg ], \@perfdata
     ) if scalar @msg_warn;
 
     return status_ok( $me, \@msg, \@perfdata );
@@ -8562,6 +8591,7 @@ GetOptions(
         'dbexclude=s',
         'dbinclude=s',
         'debug!',
+        'detailed!',
         'dump-status-file!',
         'dump-bin-file:s',
         'effective_cache_size=i',

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -165,6 +165,10 @@ my %services = (
         'sub'  => \&check_oldest_idlexact,
         'desc' => 'Check the oldest idle transaction.'
     },
+    'oldest_xmin' => {
+        'sub'  => \&check_oldest_xmin,
+        'desc' => 'Check the xmin horizon per distinct sources of xmin retention.'
+    },
     'longest_query' => {
         'sub'  => \&check_longest_query,
         'desc' => 'Check the longest running query.'
@@ -5701,6 +5705,167 @@ sub check_oldest_idlexact {
 
     return status_warning( $me, \@msg, \@perfdata )
         if $oldest_idle > $w_limit;
+
+    return status_ok( $me, \@msg, \@perfdata );
+}
+
+
+=item B<oldest_xmin> (8.4+)
+
+Check the xmin I<horizon> per distinct sources of xmin retention.
+
+Perfdata contains the oldest xmin and maximum age for the following source of
+xmin retention: C<query> (a currently executing query), C<active_xact> (an
+opened transaction currently executin a query), C<idle_xact> (an opened
+transaction being idle), C<2pc> (a pending prepared transaction), C<repslot> (a
+recpliation slot) and C<walwender> (a WAL sender replication process).  If a
+source doesn't retain any transaction, NaN is returned.
+For versions prior to 9.4, only C<2pc> source of xmin retention is available,
+so other sources won't appear in the perfdata.
+
+Critical and Warning thresholds only accept a raw number of transaction.
+
+Required privileges: an unprivileged role checks only its own queries;
+a pg_read_all_stats (10+) or superuser (<10) role is required to check
+pg_stat_replication.  2PC, pg_stat_activity, and replication slots don't
+require special privileges.
+
+=cut
+
+sub check_oldest_xmin {
+    my @rs;
+    my @perfdata;
+    my @msg;
+    my @msg_crit;
+    my @msg_warn;
+    my @hosts;
+    my $c_limit;
+    my $w_limit;
+    my %args        = %{ $_[0] };
+    my $me          = 'POSTGRES_OLDEST_XMIN';
+    my %queries     = (
+        # 8.4 is the first supported version as we rely on window functions to
+        # get the oldest xmin.  Only 2PC has transaction information available
+        $PG_VERSION_84 => q{
+        WITH ordered AS (
+          SELECT '2pc' AS kind,
+          -- xid type doesn't have range operators as the value will wraparound.
+          -- Instead, rely on age() function and row_number() window function
+          -- to get the oldest xid found.
+          row_number() OVER (
+            ORDER BY age(transaction) DESC NULLS LAST
+          ) rownum, age(transaction) AS age, transaction
+          FROM (SELECT transaction FROM pg_prepared_xact
+            UNION ALL SELECT NULL
+          ) sql
+        )
+        SELECT kind, age, xmin FROM ordered
+        WHERE rownum = 1
+        },
+        # backend_xmin and backend_xid added to pg_stat_activity,
+        # backend_xmin added to pg_stat_replication,
+        # replication slots introduced
+        $PG_VERSION_94 => q{
+        WITH raw AS (
+          -- regular backends
+          SELECT
+          CASE WHEN xact_start = query_start
+            THEN 'query'
+            ELSE
+              CASE WHEN state = 'idle in transaction'
+                THEN 'idle_xact'
+                ELSE 'active_xact'
+              END
+          END AS kind,
+          coalesce(backend_xmin, backend_xid) AS xmin
+          FROM pg_stat_activity
+          UNION ALL (
+            -- 2PC
+            SELECT '2pc' AS kind,
+            transaction AS xmin
+            FROM  pg_prepared_xacts
+            WHERE database = current_database()
+          ) UNION ALL (
+            -- replication slots
+            SELECT 'repslot' AS kind, xmin AS xmin
+            FROM  pg_replication_slots
+            WHERE coalesce(database, current_database()) = current_database()
+          ) UNION ALL (
+            -- walsenders
+            SELECT 'walsender' AS kind, backend_xmin AS xmin
+            FROM pg_stat_replication
+          )
+        ),
+        ordered AS (
+          SELECT f.kind,
+          -- xid type doesn't have range operators as the value will wraparound.
+          -- Instead, rely on age() function and row_number() window function
+          -- to get the oldest xid found.
+          row_number() OVER (
+            PARTITION BY f.kind
+            ORDER BY age(xmin) DESC NULLS LAST
+          ) rownum, age(xmin) AS age, xmin
+          FROM raw
+          RIGHT JOIN (
+            SELECT           'query'
+            UNION ALL SELECT 'idle_xact'
+            UNION ALL SELECT 'active_xact'
+            UNION ALL SELECT '2pc'
+            UNION ALL SELECT 'repslot'
+            UNION ALL SELECT 'walsender'
+          ) f(kind) ON raw.kind = f.kind
+        )
+        SELECT kind, age, xmin FROM ordered
+        WHERE rownum = 1
+        }
+    );
+
+    # warning and critical must be raw.
+    pod2usage(
+        -message => "FATAL: critical and warning thresholds only accept raw number of transactions.",
+        -exitval => 127
+    ) unless $args{'warning'}  =~ m/^([0-9.]+)$/
+        and  $args{'critical'} =~ m/^([0-9.]+)$/;
+
+    $c_limit = $args{'critical'};
+    $w_limit = $args{'warning'};
+
+    @hosts = @{ parse_hosts %args };
+
+    pod2usage(
+        -message => 'FATAL: you must give only one host with service "oldest_xmin".',
+        -exitval => 127
+    ) if @hosts != 1;
+
+    is_compat $hosts[0], 'oldest_xmin', $PG_VERSION_84 or exit 1;
+
+    @rs = @{ query_ver( $hosts[0], %queries ) };
+
+    REC_LOOP: foreach my $r (@rs) {
+        map { $_ = 'NaN' if $_ eq ''} @{$r}[1..2];
+        push @perfdata => (
+            ["$r->[0]_age", $r->[1]],
+            ["$r->[0]_xmin", $r->[2]]
+        );
+        if (defined $c_limit) {
+            if ($r->[1] ne 'NaN' and $r->[1] > $c_limit) {
+                push @msg_crit => "$r->[0]_age";
+                next REC_LOOP;
+            }
+
+            push @msg_warn => "$r->[0]_age"
+                if ($r->[1] ne 'NaN' and $r->[1] > $w_limit);
+        }
+    }
+
+    return status_critical( $me, [
+        'Critical: '. join(',', @msg_crit)
+        . (scalar @msg_warn? 'Warning: '. join(',', @msg_warn):'')
+    ], \@perfdata ) if scalar @msg_crit;
+
+    return status_warning( $me,
+        [ 'Warning: '. join(',', @msg_warn) ], \@perfdata
+    ) if scalar @msg_warn;
 
     return status_ok( $me, \@msg, \@perfdata );
 }

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5729,7 +5729,8 @@ connectable database.  If a source doesn't retain any transaction for a
 database, NaN is returned.  For versions prior to 9.4, only C<2pc> source of
 xmin retention is available, so other sources won't appear in the perfdata.
 
-Critical and Warning thresholds only accept a raw number of transaction.
+Critical and Warning thresholds are optional. They only accept a raw number of
+transaction.
 
 This service supports both C<--dbexclude>" and C<--dbinclude>" parameters.
 
@@ -5855,20 +5856,25 @@ sub check_oldest_xmin {
 
     # Warning and critical are mandatory.
     pod2usage(
-        -message => "FATAL: you must specify critical and warning thresholds.",
+        -message => "FATAL: you must specify both critical and warning thresholds or none of them.",
         -exitval => 127
-    ) unless defined $args{'warning'} and defined $args{'critical'} ;
+    ) unless (    defined $args{'warning'} and     defined $args{'critical'})
+        or   (not defined $args{'warning'} and not defined $args{'critical'});
 
-    # warning and critical must be raw.
-    pod2usage(
-        -message => "FATAL: critical and warning thresholds only accept raw number of transactions.",
-        -exitval => 127
-    ) unless $args{'warning'}  =~ m/^([0-9.]+)$/
-        and  $args{'critical'} =~ m/^([0-9.]+)$/;
+    if ( defined $args{'critical'} ) {
+
+        $c_limit  = $args{'critical'};
+        $w_limit  = $args{'warning'};
+
+        # warning and critical must be raw.
+        pod2usage(
+            -message => "FATAL: critical and warning thresholds only accept raw number of transactions.",
+            -exitval => 127
+        ) unless $args{'warning'}  =~ m/^([0-9.]+)$/
+            and $args{'critical'} =~ m/^([0-9.]+)$/;
+    }
 
     $detailed = $args{'detailed'};
-    $c_limit  = $args{'critical'};
-    $w_limit  = $args{'warning'};
 
     @hosts = @{ parse_hosts %args };
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5728,6 +5728,8 @@ replication slot) and C<walwender> (a WAL sender replication process), for each
 connectable database.  If a source doesn't retain any transaction for a
 database, NaN is returned.  For versions prior to 9.4, only C<2pc> source of
 xmin retention is available, so other sources won't appear in the perfdata.
+Note that xmin retention from walsender is only set if C<hot_standby_feedback>
+is enabled on remote standby.
 
 Critical and Warning thresholds are optional. They only accept a raw number of
 transaction.

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5854,7 +5854,7 @@ sub check_oldest_xmin {
         }
     );
 
-    # Warning and critical are mandatory.
+    # Either both warning and critical are required or none.
     pod2usage(
         -message => "FATAL: you must specify both critical and warning thresholds or none of them.",
         -exitval => 127
@@ -8716,6 +8716,13 @@ pod2usage(
     -message => 'FATAL: "slave" is only allowed with "streaming_delta" service.',
     -exitval => 127
 ) if scalar @{ $args{'slave'} }  and $args{'service'} ne 'streaming_delta';
+
+
+# Check "oldest_xmin" specific args --detailed
+pod2usage(
+    -message => 'FATAL: "detailed" argument is only allowed with "oldest_xmin" service.',
+    -exitval => 127
+) if scalar $args{'detailed'} and $args{'service'} ne 'oldest_xmin';
 
 
 # Set psql absolute path

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5715,9 +5715,14 @@ sub check_oldest_idlexact {
 
 Check the xmin I<horizon> from distinct sources of xmin retention.
 
-Perfdata contains the oldest xmin and maximum age for the following source of
-xmin retention: C<query> (a running query), C<active_xact> (an
-opened transaction currently executing a query), C<idle_xact> (an opened
+Per default, Perfdata outputs the oldest known xmin age for each database among
+running queries, opened or idle transactions, pending prepared transactions,
+replication slots and walsender. For versions prior to 9.4, only C<2pc> source
+of xmin retention is checked.
+
+Using C<--detailed>, Perfdata contains the oldest xmin and maximum age for the
+following source of xmin retention: C<query> (a running query), C<active_xact>
+(an opened transaction currently executing a query), C<idle_xact> (an opened
 transaction being idle), C<2pc> (a pending prepared transaction), C<repslot> (a
 replication slot) and C<walwender> (a WAL sender replication process), for each
 connectable database.  If a source doesn't retain any transaction for a
@@ -5726,7 +5731,7 @@ xmin retention is available, so other sources won't appear in the perfdata.
 
 Critical and Warning thresholds only accept a raw number of transaction.
 
-This service supports both "--dbexclude" and "--dbinclude" parameters.
+This service supports both C<--dbexclude>" and C<--dbinclude>" parameters.
 
 Required privileges: a pg_read_all_stats (10+) or superuser (<10) role is
 required to check pg_stat_replication.  2PC, pg_stat_activity, and replication

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5712,23 +5712,22 @@ sub check_oldest_idlexact {
 
 =item B<oldest_xmin> (8.4+)
 
-Check the xmin I<horizon> per distinct sources of xmin retention.
+Check the xmin I<horizon> from distinct sources of xmin retention.
 
 Perfdata contains the oldest xmin and maximum age for the following source of
 xmin retention: C<query> (a currently executing query), C<active_xact> (an
 opened transaction currently executin a query), C<idle_xact> (an opened
 transaction being idle), C<2pc> (a pending prepared transaction), C<repslot> (a
-recpliation slot) and C<walwender> (a WAL sender replication process).  If a
-source doesn't retain any transaction, NaN is returned.
-For versions prior to 9.4, only C<2pc> source of xmin retention is available,
-so other sources won't appear in the perfdata.
+recpliation slot) and C<walwender> (a WAL sender replication process), for each
+connectable database.  If a source doesn't retain any transaction for a
+database, NaN is returned.  For versions prior to 9.4, only C<2pc> source of
+xmin retention is available, so other sources won't appear in the perfdata.
 
 Critical and Warning thresholds only accept a raw number of transaction.
 
-Required privileges: an unprivileged role checks only its own queries;
-a pg_read_all_stats (10+) or superuser (<10) role is required to check
-pg_stat_replication.  2PC, pg_stat_activity, and replication slots don't
-require special privileges.
+Required privileges: a pg_read_all_stats (10+) or superuser (<10) role is
+required to check pg_stat_replication.  2PC, pg_stat_activity, and replication
+slots don't require special privileges.
 
 =cut
 
@@ -5749,17 +5748,24 @@ sub check_oldest_xmin {
         $PG_VERSION_84 => q{
         WITH ordered AS (
           SELECT '2pc' AS kind,
+          d.datname,
           -- xid type doesn't have range operators as the value will wraparound.
           -- Instead, rely on age() function and row_number() window function
           -- to get the oldest xid found.
           row_number() OVER (
+            PARTITION BY d.datname
             ORDER BY age(transaction) DESC NULLS LAST
-          ) rownum, age(transaction) AS age, transaction
-          FROM (SELECT transaction FROM pg_prepared_xact
-            UNION ALL SELECT NULL
-          ) sql
+          ) rownum, age(transaction) AS age,
+          transaction AS xmin
+          FROM (SELECT transaction, database FROM pg_prepared_xacts
+            UNION ALL SELECT NULL, NULL
+          ) sql(transaction, datname)
+          -- we use this JOIN condition to make sure that we'll always have a
+          -- full record for all (connectable) databases
+          JOIN pg_database d ON d.datname = coalesce(sql.datname, d.datname)
+          WHERE d.datallowconn
         )
-        SELECT kind, age, xmin FROM ordered
+        SELECT kind, datname, age, xmin FROM ordered
         WHERE rownum = 1
         },
         # backend_xmin and backend_xid added to pg_stat_activity,
@@ -5777,45 +5783,58 @@ sub check_oldest_xmin {
                 ELSE 'active_xact'
               END
           END AS kind,
+          datname,
           coalesce(backend_xmin, backend_xid) AS xmin
           FROM pg_stat_activity
+          -- exclude ourselves, as a blocked xmin in another database would be
+          -- exposed in the database we're connecting too, which may otherwise
+          -- not have the same xmin
+          WHERE pid != pg_backend_pid()
           UNION ALL (
             -- 2PC
             SELECT '2pc' AS kind,
+            database AS datname,
             transaction AS xmin
             FROM  pg_prepared_xacts
-            WHERE database = current_database()
           ) UNION ALL (
             -- replication slots
-            SELECT 'repslot' AS kind, xmin AS xmin
+            SELECT 'repslot' AS kind,
+            database AS datname,
+            xmin AS xmin
             FROM  pg_replication_slots
-            WHERE coalesce(database, current_database()) = current_database()
           ) UNION ALL (
             -- walsenders
-            SELECT 'walsender' AS kind, backend_xmin AS xmin
+            SELECT 'walsender' AS kind,
+            NULL AS datname,
+            backend_xmin AS xmin
             FROM pg_stat_replication
           )
         ),
         ordered AS (
-          SELECT f.kind,
+          SELECT f.kind, d.datname,
           -- xid type doesn't have range operators as the value will wraparound.
           -- Instead, rely on age() function and row_number() window function
           -- to get the oldest xid found.
           row_number() OVER (
-            PARTITION BY f.kind
+            PARTITION BY f.kind, d.datname
             ORDER BY age(xmin) DESC NULLS LAST
           ) rownum, age(xmin) AS age, xmin
           FROM raw
-          RIGHT JOIN (
-            SELECT           'query'
-            UNION ALL SELECT 'idle_xact'
-            UNION ALL SELECT 'active_xact'
-            UNION ALL SELECT '2pc'
-            UNION ALL SELECT 'repslot'
-            UNION ALL SELECT 'walsender'
+          RIGHT JOIN (VALUES
+            ( 'query'       ),
+            ( 'idle_xact'   ),
+            ( 'active_xact' ),
+            ( '2pc'         ),
+            ( 'repslot'     ),
+            ( 'walsender'   )
           ) f(kind) ON raw.kind = f.kind
+          -- we use this JOIN condition to make sure that we'll always have a
+          -- full record for all (connectable) databases
+          JOIN pg_database d ON d.datname = coalesce(raw.datname, d.datname)
+          WHERE d.datallowconn
         )
-        SELECT kind, age, xmin FROM ordered
+        SELECT kind, datname, age, xmin
+        FROM ordered
         WHERE rownum = 1
         }
     );
@@ -5842,25 +5861,25 @@ sub check_oldest_xmin {
     @rs = @{ query_ver( $hosts[0], %queries ) };
 
     REC_LOOP: foreach my $r (@rs) {
-        map { $_ = 'NaN' if $_ eq ''} @{$r}[1..2];
+        map { $_ = 'NaN' if $_ eq ''} @{$r}[2..3];
         push @perfdata => (
-            ["$r->[0]_age", $r->[1]],
-            ["$r->[0]_xmin", $r->[2]]
+            ["$r->[0]_$r->[1]_age", $r->[2]],
+            ["$r->[0]_$r->[1]_xmin", $r->[3]]
         );
         if (defined $c_limit) {
-            if ($r->[1] ne 'NaN' and $r->[1] > $c_limit) {
-                push @msg_crit => "$r->[0]_age";
+            if ($r->[2] ne 'NaN' and $r->[2] > $c_limit) {
+                push @msg_crit => "$r->[0]_$r->[1]_age";
                 next REC_LOOP;
             }
 
-            push @msg_warn => "$r->[0]_age"
-                if ($r->[1] ne 'NaN' and $r->[1] > $w_limit);
+            push @msg_warn => "$r->[0]_$r->[1]_age"
+                if ($r->[2] ne 'NaN' and $r->[2] > $w_limit);
         }
     }
 
     return status_critical( $me, [
         'Critical: '. join(',', @msg_crit)
-        . (scalar @msg_warn? 'Warning: '. join(',', @msg_warn):'')
+        . (scalar @msg_warn? ' Warning: '. join(',', @msg_warn):'')
     ], \@perfdata ) if scalar @msg_crit;
 
     return status_warning( $me,

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5725,6 +5725,8 @@ xmin retention is available, so other sources won't appear in the perfdata.
 
 Critical and Warning thresholds only accept a raw number of transaction.
 
+This service supports both "--dbexclude" and "--dbinclude" parameters.
+
 Required privileges: a pg_read_all_stats (10+) or superuser (<10) role is
 required to check pg_stat_replication.  2PC, pg_stat_activity, and replication
 slots don't require special privileges.
@@ -5740,9 +5742,11 @@ sub check_oldest_xmin {
     my @hosts;
     my $c_limit;
     my $w_limit;
-    my %args    = %{ $_[0] };
-    my $me      = 'POSTGRES_OLDEST_XMIN';
-    my %queries = (
+    my %args      = %{ $_[0] };
+    my $me        = 'POSTGRES_OLDEST_XMIN';
+    my @dbinclude = @{ $args{'dbinclude'} };
+    my @dbexclude = @{ $args{'dbexclude'} };
+    my %queries   = (
         # 8.4 is the first supported version as we rely on window functions to
         # get the oldest xmin.  Only 2PC has transaction information available
         $PG_VERSION_84 => q{
@@ -5765,7 +5769,7 @@ sub check_oldest_xmin {
           JOIN pg_database d ON d.datname = coalesce(sql.datname, d.datname)
           WHERE d.datallowconn
         )
-        SELECT kind, datname, age, xmin FROM ordered
+        SELECT datname, kind, age, xmin FROM ordered
         WHERE rownum = 1
         },
         # backend_xmin and backend_xid added to pg_stat_activity,
@@ -5811,33 +5815,41 @@ sub check_oldest_xmin {
           )
         ),
         ordered AS (
-          SELECT f.kind, d.datname,
+          SELECT kind, datname,
           -- xid type doesn't have range operators as the value will wraparound.
           -- Instead, rely on age() function and row_number() window function
           -- to get the oldest xid found.
           row_number() OVER (
-            PARTITION BY f.kind, d.datname
+            PARTITION BY kind, datname
             ORDER BY age(xmin) DESC NULLS LAST
           ) rownum, age(xmin) AS age, xmin
           FROM raw
-          RIGHT JOIN (VALUES
+        )
+        SELECT f.datname, f.kind, o.age, o.xmin
+        FROM ordered AS o
+        RIGHT JOIN (
+          SELECT d.datname, v.kind
+          FROM pg_catalog.pg_database d,
+          (VALUES
             ( 'query'       ),
             ( 'idle_xact'   ),
             ( 'active_xact' ),
             ( '2pc'         ),
             ( 'repslot'     ),
             ( 'walsender'   )
-          ) f(kind) ON raw.kind = f.kind
-          -- we use this JOIN condition to make sure that we'll always have a
-          -- full record for all (connectable) databases
-          JOIN pg_database d ON d.datname = coalesce(raw.datname, d.datname)
+          ) v(kind)
           WHERE d.datallowconn
-        )
-        SELECT kind, datname, age, xmin
-        FROM ordered
-        WHERE rownum = 1
+        ) f ON o.datname = f.datname
+           AND o.kind = f.kind
+        WHERE coalesce(o.rownum, 1) = 1
         }
     );
+
+    # Warning and critical are mandatory.
+    pod2usage(
+        -message => "FATAL: you must specify critical and warning thresholds.",
+        -exitval => 127
+    ) unless defined $args{'warning'} and defined $args{'critical'} ;
 
     # warning and critical must be raw.
     pod2usage(
@@ -5861,7 +5873,12 @@ sub check_oldest_xmin {
     @rs = @{ query_ver( $hosts[0], %queries ) };
 
     REC_LOOP: foreach my $r (@rs) {
+
+        next REC_LOOP if @dbexclude and     grep { $r->[0] =~ /$_/ } @dbexclude;
+        next REC_LOOP if @dbinclude and not grep { $r->[0] =~ /$_/ } @dbinclude;
+
         map { $_ = 'NaN' if $_ eq ''} @{$r}[2..3];
+
         push @perfdata => (
             ["$r->[0]_$r->[1]_age", $r->[2]],
             ["$r->[0]_$r->[1]_xmin", $r->[3]]

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -167,7 +167,7 @@ my %services = (
     },
     'oldest_xmin' => {
         'sub'  => \&check_oldest_xmin,
-        'desc' => 'Check the xmin horizon per distinct sources of xmin retention.'
+        'desc' => 'Check the xmin horizon from distinct sources of xmin retention.'
     },
     'longest_query' => {
         'sub'  => \&check_longest_query,
@@ -5715,10 +5715,10 @@ sub check_oldest_idlexact {
 Check the xmin I<horizon> from distinct sources of xmin retention.
 
 Perfdata contains the oldest xmin and maximum age for the following source of
-xmin retention: C<query> (a currently executing query), C<active_xact> (an
-opened transaction currently executin a query), C<idle_xact> (an opened
+xmin retention: C<query> (a running query), C<active_xact> (an
+opened transaction currently executing a query), C<idle_xact> (an opened
 transaction being idle), C<2pc> (a pending prepared transaction), C<repslot> (a
-recpliation slot) and C<walwender> (a WAL sender replication process), for each
+replication slot) and C<walwender> (a WAL sender replication process), for each
 connectable database.  If a source doesn't retain any transaction for a
 database, NaN is returned.  For versions prior to 9.4, only C<2pc> source of
 xmin retention is available, so other sources won't appear in the perfdata.
@@ -5740,9 +5740,9 @@ sub check_oldest_xmin {
     my @hosts;
     my $c_limit;
     my $w_limit;
-    my %args        = %{ $_[0] };
-    my $me          = 'POSTGRES_OLDEST_XMIN';
-    my %queries     = (
+    my %args    = %{ $_[0] };
+    my $me      = 'POSTGRES_OLDEST_XMIN';
+    my %queries = (
         # 8.4 is the first supported version as we rely on window functions to
         # get the oldest xmin.  Only 2PC has transaction information available
         $PG_VERSION_84 => q{


### PR DESCRIPTION
This implements the check mentioned in https://github.com/OPMDG/check_pgactivity/issues/201.

I'm not extremely sure of the pg_stat_activity part.  The problems I can see are:

- as soon as eg. a transaction retains some xid, active queries started after will also look like they're retaining the same amount of transactions.  However, if t hose queries continue to run after the initial transaction is finished, they'll be the source of retention.  So it's quite hard to really identify what actually retains the xmin horizons from an aggregated view.  The query is already complex enough, so I'm not in favor of adding extra steps to try to be smarter about that.

- For pg_stat_activity, I'm not exactly sure if both backend_xmin *and* backend_xid can both be earlier than the other.  Minimal testing showed than `coalesce(backend_xmin, backend_xid)` was enough, but I certainly didn't try a lot of scenario.