### PR TITLE
Fix backend count for PostgreSQL version 10 and a typo in 12.

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -2126,7 +2126,7 @@ sub check_backends {
                 SELECT d.datname, count(*)
                 FROM pg_catalog.pg_stat_activity AS s
                   JOIN pg_catalog.pg_database AS d ON d.oid = s.datid
-                WHERE backend_type IN ('client backend', 'background worker')
+                WHERE backend_type = 'client backend'
                 GROUP BY d.datname
                 UNION ALL
                 SELECT 'replication', count(*)
@@ -2139,7 +2139,7 @@ sub check_backends {
                 SELECT d.datname, count(*)
                 FROM pg_catalog.pg_stat_activity AS s
                   JOIN pg_catalog.pg_database AS d ON d.oid = s.datid
-                WHERE backend_type IN ('client backend', 'background worker')
+                WHERE backend_type = 'client backend'
                 GROUP BY d.datname
             ) AS s }
     );


### PR DESCRIPTION
- query PG_VERSION_100: background workers shouldnt count towards
  client_backends. With this patch 'backend_type' is now restricted
  to 'client backend' only since walsenders are accounted for using
  pg_stat_replication.

- query PG_VERSION_120: the modification is the same here. Except that
  the result of the query was correct because the backend_type
  'background worker' doesn't exist anymore, it was replaced by 'logical
  replication worker' and 'parallel worker' in version 11.