### PR TITLE
Fix check_pga to run on prehistoric Perl installation

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -8320,11 +8320,6 @@ unless (($args{'service'} eq 'pg_dump_backup') or ($args{'service'} eq 'oldest_i
 
 $_ = qr/$_/ for @{ $args{'dbexclude'} };
 
-if ( $args{'format'} =~ '^json' ) {
-    require JSON::PP;
-    JSON::PP->import;
-}
-
 # Output format
 for ( $args{'format'} ) {
        if ( /^binary$/        ) { $output_fmt = \&bin_output  }
@@ -8340,6 +8335,11 @@ for ( $args{'format'} ) {
             -exitval => 127
         );
     }
+}
+
+if ( $args{'format'} =~ '^json' ) {
+    require JSON::PP;
+    JSON::PP->import;
 }
 
 exit $services{ $args{'service'} }{'sub'}->( \%args );

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -33,7 +33,6 @@ use File::Basename;
 use File::Spec;
 use File::Temp ();
 use Getopt::Long qw(:config bundling no_ignore_case_always);
-use JSON::PP;
 use List::Util qw(max);
 use Pod::Usage;
 use Scalar::Util qw(looks_like_number);
@@ -8320,6 +8319,11 @@ unless (($args{'service'} eq 'pg_dump_backup') or ($args{'service'} eq 'oldest_i
 }
 
 $_ = qr/$_/ for @{ $args{'dbexclude'} };
+
+if ( $args{'format'} =~ '^json' ) {
+    require JSON::PP;
+    JSON::PP->import;
+}
 
 # Output format
 for ( $args{'format'} ) {


### PR DESCRIPTION
In dark ancient ages, Perl didn't provide JSON::PP by default. This PR fixes issue #253.

Regards
