### PR TITLE
Use pg_ls_tmpdir() in check_temp_files

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -7420,7 +7420,7 @@ that it cannot access, nor live temp files
  v11: an unprivileged role is possible but must be granted EXECUTE
 on functions pg_ls_dir(text), pg_read_file(text), pg_stat_file(text);
 the same restrictions than on v10 will still apply
- v12: a user with the role pg_monitor suffices.  
+ v12: a role with pg_monitor privilege.  
 
 =cut
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -7420,8 +7420,7 @@ that it cannot access, nor live temp files
  v11: an unprivileged role is possible but must be granted EXECUTE
 on functions pg_ls_dir(text), pg_read_file(text), pg_stat_file(text);
 the same restrictions than on v10 will still apply
- v12: a user with the role pg_monitor suffices. unprivileged role is not
-supported anymore
+ v12: a user with the role pg_monitor suffices.  
 
 =cut
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -7420,6 +7420,8 @@ that it cannot access, nor live temp files
  v11: an unprivileged role is possible but must be granted EXECUTE
 on functions pg_ls_dir(text), pg_read_file(text), pg_stat_file(text);
 the same restrictions than on v10 will still apply
+ v12: a user with the role pg_monitor suffices. unprivileged role is not
+supported anymore
 
 =cut
 
@@ -7594,7 +7596,29 @@ sub check_temp_files {
           SELECT 'db', d.datname, s.temp_files, s.temp_bytes
             FROM pg_database AS d
             JOIN pg_stat_database AS s ON s.datid=d.oid
-    },
+        },
+	# Use pg_ls_tmpdir with PostgreSQL 12
+	# The technic to bypass function execution for non-superuser roles used in
+	# the query PG_VERSION_100 does not work anymore since commit b8d7f053c5c in
+	# PostgreSQL. From now on, this probe requires at least a pg_monitor role to
+	# perform with PostgreSQL >= 12.
+        $PG_VERSION_120 => q{
+          SELECT 'live', agg.spcname, count(agg.name),
+                 SUM(agg.size) AS SIZE
+            FROM (
+            SELECT ts.spcname,
+                   tmp.name,
+                   tmp.size
+              FROM pg_tablespace ts,
+              LATERAL pg_catalog.pg_ls_tmpdir(ts.oid) tmp
+                 WHERE spcname <> 'pg_global'
+                 ) AS agg
+           GROUP BY 1, 2
+          UNION ALL
+          SELECT 'db', d.datname, s.temp_files, s.temp_bytes
+            FROM pg_database AS d
+            JOIN pg_stat_database AS s ON s.datid=d.oid;
+        },
     );
 
     @hosts = @{ parse_hosts %args };


### PR DESCRIPTION
PostgreSQL 12 introduced function pg_ls_tmpdir to list live temp files
in a given tablespace. This function requires the pg_monitor privilege