### PR TITLE
do not error on missing file in check_temp_files for version 10+

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -7572,7 +7572,7 @@ sub check_temp_files {
         # PostgreSQL 10
         $PG_VERSION_100 => q{
           SELECT 'live', agg.spcname, count(agg.tmpfile),
-                 SUM((pg_stat_file(agg.dir||'/'||agg.tmpfile)).size) AS SIZE
+                 SUM(COALESCE((pg_stat_file(agg.dir||'/'||agg.tmpfile, true)).size, 0)) AS SIZE
             FROM ( SELECT ls.oid, ls.spcname AS spcname,
                           ls.dir||'/'||ls.sub AS dir,
                           pg_ls_dir(ls.dir||'/'||ls.sub) AS tmpfile

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -7421,7 +7421,7 @@ Required privileges:
  v10: an unprivileged role is possible but it will not monitor databases
 that it cannot access, nor live temp files
  v11: an unprivileged role is possible but must be granted EXECUTE
-on functions pg_ls_dir(text), pg_read_file(text), pg_stat_file(text);
+on functions pg_ls_dir(text), pg_read_file(text), pg_stat_file(text, boolean);
 the same restrictions than on v10 will still apply
  v12+: a role with pg_monitor privilege.
 


### PR DESCRIPTION
In the check_temp_files, since we are first getting file list before getting their size, some files could get missing in the meantime. The check then fails with the following error:
```
CHECK_PGACTIVITY UNKNOWN: Query failed !
psql:/tmp/check_pga-pBGcyGwB:29: ERROR:  could not stat file base/pgsql_tmp/pgsql_tmp25560.109: No such file or directory
```

Update the SQL query for versions 10+ to return a size of 0 for the missing files.