### PR TITLE
Wal_files on PG13 : wal_keep_segments (issue #266)

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -8201,7 +8201,7 @@ sub check_wal_files {
         $curr_lsn =~ m{^([0-9A-F]+)/([0-9A-F]+)$};
         $curr_lsn = ( $wal_size * hex($1) ) + hex($2);
 
-        unless ( @prev_lsn == 0 ) {
+        unless ( @prev_lsn == 0 or $now == $prev_lsn[0] ) {
             my $rate = ($curr_lsn - $prev_lsn[1])/($now - $prev_lsn[0]);
             $rate = int($rate*100+0.5)/100;
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -7948,10 +7948,14 @@ of the following formulas:
   100% = 1 + checkpoint_segments * (2 + checkpoint_completion_target)
   100% = 1 + wal_keep_segments + 2 * checkpoint_segments
 
-For 9.5 and above, the limit is:
+For 9.5 to 12, the limit is:
 
   100% =  max_wal_size      (as a number of WAL)
         + wal_keep_segments (if set)
+
+For 13 and above:
+
+  100% =  max_wal_size + wal_keep_size (as numbers of WAL)
 
 Required privileges:
  <10:superuser (<10)
@@ -7981,6 +7985,28 @@ sub check_wal_files {
      # compare against the current number of WALs (see rules above).
      # Parameters and the units stored in pg_settings have changed often across
      # versions.
+     $PG_VERSION_130 => q{
+        WITH wal_settings AS (
+          SELECT sum(setting::int) filter (WHERE name='max_wal_size') as max_wal_size, -- unit: MB
+                 sum(setting::int) filter (WHERE name='wal_segment_size') as wal_segment_size, -- unit: B
+                 sum(setting::int) filter (WHERE name='wal_keep_size') as wal_keep_size -- unit: MB
+          FROM pg_settings
+          WHERE name IN ('max_wal_size','wal_segment_size','wal_keep_size')
+        )
+        SELECT s.name,
+          (wal_keep_size + max_wal_size) / (wal_segment_size/1024^2)  AS max_nb_wal, -- unit: nb of WALs
+          CASE WHEN pg_is_in_recovery()
+            THEN NULL
+            ELSE pg_current_wal_lsn()
+          END,
+          floor(wal_keep_size / (wal_segment_size/1024^2)) AS wal_keep_segments, -- unit: nb of WALs
+          (pg_control_checkpoint()).timeline_id     AS tli
+        FROM pg_ls_waldir() AS s
+        CROSS JOIN wal_settings
+        WHERE name ~ '^[0-9A-F]{24}$'
+        ORDER BY
+          s.modification DESC,
+          name DESC},
      $PG_VERSION_110 => q{
         WITH wal_settings AS (
           SELECT sum(setting::int) filter (WHERE name='max_wal_size') as max_wal_size, -- unit: MB


### PR DESCRIPTION
On PG13+, wal_keep_size replaces wal_keep_segments.
The logic stays the same, everything is computed as number of wals.

While testing, I found that a division by zero can occur. In this cas,e just disable the wal_rate in the perfdata.

I've played with the settings and it works as expected:
![wal_files_issue266](https://user-images.githubusercontent.com/22391138/95985307-bbf5ed00-0e24-11eb-8fa2-d271a3158611.png)


