### PR TITLE
last_analyze|vacuum: a warning about NULL values in pg_stat_user_tables

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -4844,6 +4844,9 @@ returned.
 Critical and Warning thresholds only accept an interval (eg. 1h30m25s)
 and apply to the oldest execution of analyse.
 
+Tables that were never analyzed, or whose analyze date was lost due to a crash,
+will raise a critical alert.
+
 B<NOTE>: this service does not raise alerts if the database had strictly
 no writes since last call. In consequence, a read-only database can have
 its oldest analyze reported in perfdata way after your thresholds, but not
@@ -4875,6 +4878,9 @@ execution.
 
 Critical and Warning thresholds only accept an interval (eg. 1h30m25s)
 and apply to the oldest vacuum.
+
+Tables that were never vacuumed, or whose vacuum date was lost due to a crash,
+will raise a critical alert.
 
 B<NOTE>: this service does not raise alerts if the database had strictly
 no writes since last call. In consequence, a read-only database can have


### PR DESCRIPTION
This may be a surprise for some people upgrading to 2.5.