### PR TITLE
Fix check_oldest_idlexact to use state_change

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5722,7 +5722,7 @@ Above 9.2, it supports C<--exclude> to filter out connections. Eg., to
 filter out pg_dump and pg_dumpall, set this to 'pg_dump,pg_dumpall'.
 
 Before 9.2, this services checks for idle transaction with their start time.
-Thus, the service can mistakenly take account of transaction transciently in
+Thus, the service can mistakenly take account of transaction transiently in
 idle state.
 From 9.2 and up, the service checks for transaction that really had no activity
 since the given thresholds.

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5721,6 +5721,12 @@ This service supports both C<--dbexclude> and C<--dbinclude> parameters.
 Above 9.2, it supports C<--exclude> to filter out connections. Eg., to
 filter out pg_dump and pg_dumpall, set this to 'pg_dump,pg_dumpall'.
 
+Before 9.2, this services checks for idle transaction with their start time.
+Thus, the service can wrongly can take account of transaction transciently in
+idle state.
+From 9.2 and up, the service checks for transaction that had no activity since
+the given thresholds.
+
 Required privileges: an unprivileged role checks only its own queries;
 a pg_monitor (10+) or superuser (<10) role is required to check all queries.
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5749,7 +5749,7 @@ sub check_oldest_idlexact {
             LEFT JOIN pg_stat_activity AS a ON (a.datid = d.oid AND current_query = '<IDLE> in transaction')},
         $PG_VERSION_92 => q{SELECT d.datname,
             coalesce(extract('epoch' FROM
-                    date_trunc('second', current_timestamp-xact_start)
+                    date_trunc('second', current_timestamp-state_change)
                 ), -1)
             FROM pg_database AS d
             LEFT JOIN pg_stat_activity AS a ON (a.datid = d.oid AND state='idle in transaction')

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5722,10 +5722,10 @@ Above 9.2, it supports C<--exclude> to filter out connections. Eg., to
 filter out pg_dump and pg_dumpall, set this to 'pg_dump,pg_dumpall'.
 
 Before 9.2, this services checks for idle transaction with their start time.
-Thus, the service can wrongly can take account of transaction transciently in
+Thus, the service can mistakenly take account of transaction transciently in
 idle state.
-From 9.2 and up, the service checks for transaction that had no activity since
-the given thresholds.
+From 9.2 and up, the service checks for transaction that really had no activity
+since the given thresholds.
 
 Required privileges: an unprivileged role checks only its own queries;
 a pg_monitor (10+) or superuser (<10) role is required to check all queries.


### PR DESCRIPTION
Fix check_oldest_idlexact to use state_change instead of xact_start to
calculate the idle time. The previous behavior leads to warn for active
long transaction.