### PR TITLE
Support psql older than 8.4

### DIFF
--- a/README
+++ b/README
@@ -13,9 +13,13 @@ DESCRIPTION
 
 COMPATIBILITY
     Each service is available from a different PostgreSQL version, from 7.4,
-    as documented below. The psql client must be 8.3 at least. It can be
-    used with an older server. Please report any undocumented
-    incompatibility.
+    as documented below.
+
+    Ideally, the psql client should be 8.4 at least, but it can be used with
+    an older server. If your client is older, see "--psql" and "--old-psql"
+    for more information.
+
+    Please report any undocumented incompatibility.
 
     -s, --service SERVICE
         The Nagios service to run. See section SERVICES for a description of
@@ -97,8 +101,23 @@ COMPATIBILITY
         script relies on the system default temporary directory if possible.
 
     -P, --psql FILE
-        Path to the "psql" executable (default: "psql"). It should be
-        version 8.3 at least, but the server can be older.
+        Path to the "psql" executable (default: "psql").
+
+        Because check_pgactivity uses "psql -w", "psql" must be version 8.4
+        at least, but the server can be older. If your "psql" is older and
+        does not support "-w", look at argument "--old-psql".
+
+    --old-psql
+        Stay compatible with psql 8.3 and below.
+
+        Can also be set be setting environment variable
+        "CHECK_PGA_OLD_PSQL".
+
+        This option removes the "-w" argument from the "psql" argument list.
+        This means that if your password-less authentication is not
+        correctly setup, "psql" might either wait indefinitely for a
+        password, effectively blocking "check_pgactivity", or fail
+        immediately with an explicit error message.
 
     --status-file PATH
         Path to the file where service status information is kept between

--- a/README.pod
+++ b/README.pod
@@ -15,9 +15,13 @@ offers many options to measure and monitor useful performance metrics.
 
 =head1 COMPATIBILITY
 
-Each service is available from a different PostgreSQL version,
-from 7.4, as documented below.
-The psql client must be 8.3 at least. It can be used with an older server.
+Each service is available from a different PostgreSQL version, from 7.4, as
+documented below.
+
+Ideally, the psql client should be 8.4 at least, but it can be used with an
+older server. If your client is older, see C<--psql> and C<--old-psql> for more
+information.
+
 Please report any undocumented incompatibility.
 
 =over
@@ -114,7 +118,21 @@ script relies on the system default temporary directory if possible.
 =item B<-P>, B<--psql> FILE
 
 Path to the C<psql> executable (default: "psql").
-It should be version 8.3 at least, but the server can be older.
+
+Because check_pgactivity uses C<psql -w>, C<psql> must be version 8.4 at least,
+but the server can be older. If your C<psql> is older and does not support
+C<-w>, look at argument C<--old-psql>.
+
+=item B<--old-psql>
+
+Stay compatible with psql 8.3 and below.
+
+Can also be set be setting environment variable C<CHECK_PGA_OLD_PSQL>.
+
+This option removes the C<-w> argument from the C<psql> argument list. This
+means that if your password-less authentication is not correctly setup, C<psql>
+might either wait indefinitely for a password, effectively blocking
+C<check_pgactivity>, or fail immediately with an explicit error message.
 
 =item B<--status-file> PATH
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -21,9 +21,13 @@ offers many options to measure and monitor useful performance metrics.
 
 =head1 COMPATIBILITY
 
-Each service is available from a different PostgreSQL version,
-from 7.4, as documented below.
-The psql client must be 8.3 at least. It can be used with an older server.
+Each service is available from a different PostgreSQL version, from 7.4, as
+documented below.
+
+Ideally, the psql client should be 8.4 at least, but it can be used with an
+older server. If your client is older, see C<--psql> and C<--old-psql> for more
+information.
+
 Please report any undocumented incompatibility.
 
 =cut
@@ -380,7 +384,20 @@ script relies on the system default temporary directory if possible.
 =item B<-P>, B<--psql> FILE
 
 Path to the C<psql> executable (default: "psql").
-It should be version 8.3 at least, but the server can be older.
+
+Because check_pgactivity uses C<psql -w>, C<psql> must be version 8.4 at least,
+but the server can be older.
+
+If your C<psql> is older and does not support C<-w>, look at argument
+C<--old-psql>.
+
+=item B<--old-psql>
+
+Stay compatible with psql 8.3 and below.
+
+This option removes the C<-w> argument from the C<psql> argument list. This
+means that if your password-less authentication is not correctly setup, C<psql>
+will wait indefinitely for a password, effectively blocking C<check_pgactivity>.
 
 =item B<--status-file> PATH
 
@@ -447,6 +464,7 @@ my %args = (
     'dbinclude'             => [],
     'tmpdir'                => File::Spec->tmpdir(),
     'psql'                  => undef,
+    'old-psql'              => undef,
     'path'                  => undef,
     'status-file'           => dirname(__FILE__) . '/check_pgactivity.data',
     'output'                => dirname(__FILE__) . '/check_pgactivity.out',
@@ -1083,6 +1101,7 @@ sub query($$;$$$) {
     my $FS         = chr(3);  # ASCII ETX (end of text)
     my $get_fields = shift;
     my $onfail     = shift || \&status_unknown;
+    my $warg       = '-w';
     my $tmpfile;
     my $psqlcmd;
     my $rc;
@@ -1110,6 +1129,8 @@ sub query($$;$$$) {
     dprint ("Env. user   : $ENV{PGUSER}    \n") if defined $host->{'user'};
     dprint ("Env. db     : $ENV{PGDATABASE}\n") if defined $host->{'db'};
 
+    $warg = '' if $args{'old-psql'} or $ENV{'CHECK_PGA_OLD_PSQL'};
+
     $tmpfile = File::Temp->new(
         TEMPLATE => 'check_pga-XXXXXXXX',
         DIR      => $args{'tmpdir'}
@@ -1117,7 +1138,7 @@ sub query($$;$$$) {
 
     print $tmpfile "$query;" or die "Could not create or write in a temp file!";
 
-    $psqlcmd  = qq{ $args{'psql'} -w --set "ON_ERROR_STOP=1" }
+    $psqlcmd  = qq{ $args{'psql'} $warg --set "ON_ERROR_STOP=1" }
               . qq{ -qXAf $tmpfile -R $RS -F $FS };
     $psqlcmd .= qq{ --dbname='$db' } if defined $db;
     $res      = qx{ $psqlcmd 2>&1 };
@@ -9227,6 +9248,7 @@ GetOptions(
         'pattern=s',
         'port|p=s',
         'psql|P=s',
+        'old-psql!',
         'query=s',
         'reverse!',
         'save!',

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -386,18 +386,19 @@ script relies on the system default temporary directory if possible.
 Path to the C<psql> executable (default: "psql").
 
 Because check_pgactivity uses C<psql -w>, C<psql> must be version 8.4 at least,
-but the server can be older.
-
-If your C<psql> is older and does not support C<-w>, look at argument
-C<--old-psql>.
+but the server can be older. If your C<psql> is older and does not support
+C<-w>, look at argument C<--old-psql>.
 
 =item B<--old-psql>
 
 Stay compatible with psql 8.3 and below.
 
+Can also be set be setting environment variable C<CHECK_PGA_OLD_PSQL>.
+
 This option removes the C<-w> argument from the C<psql> argument list. This
 means that if your password-less authentication is not correctly setup, C<psql>
-will wait indefinitely for a password, effectively blocking C<check_pgactivity>.
+might either wait indefinitely for a password, effectively blocking
+C<check_pgactivity>, or fail immediately with an explicit error message.
 
 =item B<--status-file> PATH
 

--- a/t/lib/pgNode.pm
+++ b/t/lib/pgNode.pm
@@ -59,6 +59,8 @@ sub new {
     BAIL_OUT( "TAP tests does not support versions older than 8.2" )
         if $self->version < 8.2;
 
+    $ENV{'CHECK_PGA_OLD_PSQL'} = 1 if $self->version < 8.4;
+
     note('Node "', $self->{'node'}->name, '" uses version: ', $self->version);
 
     return $self;


### PR DESCRIPTION
Make possible to remove the -w argument using the --old-psql argument.

Fix #270