### PR TITLE
Fix backends_status to use state_change for pg>=9.2

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -2516,7 +2516,7 @@ sub check_backends_status {
                 ELSE s.state
               END,
               extract('epoch' FROM
-                date_trunc('milliseconds', current_timestamp-s.xact_start)
+                date_trunc('milliseconds', current_timestamp-s.state_change)
               ), current_setting('max_connections'), s.query
             FROM pg_stat_activity AS s
               JOIN pg_database d ON d.oid=s.datid
@@ -2533,7 +2533,7 @@ sub check_backends_status {
                 ELSE s.state
               END,
               extract('epoch' FROM
-                date_trunc('milliseconds', current_timestamp-s.xact_start)
+                date_trunc('milliseconds', current_timestamp-s.state_change)
               ), current_setting('max_connections'), s.query
             FROM pg_stat_activity AS s
               JOIN pg_database d ON d.oid=s.datid
@@ -2552,7 +2552,7 @@ sub check_backends_status {
                 ELSE s.state
               END,
               extract('epoch' FROM
-                date_trunc('milliseconds', current_timestamp-s.xact_start)
+                date_trunc('milliseconds', current_timestamp-s.state_change)
               ), current_setting('max_connections'), s.query
             FROM pg_stat_activity AS s
               JOIN pg_database d ON d.oid=s.datid


### PR DESCRIPTION
Previously, backends_status used xact_start to check if a transaction is waiting for a lock or is idle for a given amount of time. This leads to false positive alerts when a transaction becomes transciently idle.