### PR TITLE
Fix check_backends_status to simplify session accounting

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -2490,7 +2490,6 @@ sub check_backends_status {
         'disabled'                      => [0, 0],
         'undefined'                     => [0, 0],
         'insufficient privilege'        => [0, 0],
-        'other wait event'              => [0, 0]
     );
     my %translate    = (
         'idle'         => 'idle',
@@ -2601,7 +2600,6 @@ sub check_backends_status {
         $PG_VERSION_96 => q{
             SELECT CASE
                 WHEN s.wait_event_type = 'Lock' THEN 'waiting for lock'
-                WHEN s.wait_event_type IS NOT NULL THEN 'other wait event'
                 WHEN s.query = '<insufficient privilege>'
                     THEN 'insufficient privilege'
                 WHEN s.state IS NULL THEN 'undefined'
@@ -2621,9 +2619,6 @@ sub check_backends_status {
                 WHEN s.query = '<insufficient privilege>'
                     THEN 'insufficient privilege'
                 WHEN s.state IS NULL THEN 'undefined'
-                WHEN s.wait_event_type IS NOT NULL
-                       AND s.wait_event_type NOT IN ('Client', 'Activity')
-                     THEN 'other wait event'
                 ELSE s.state
               END,
               extract('epoch' FROM
@@ -2673,9 +2668,6 @@ sub check_backends_status {
 
     delete $status{'idle in transaction (aborted)'}
         if $hosts[0]->{'version_num'} < $PG_VERSION_90;
-
-    delete $status{'other wait event'}
-        if $hosts[0]->{'version_num'} < $PG_VERSION_96;
 
     $max_connections = $rs[0][2] if scalar @rs;
 

--- a/t/01-backends_status.t
+++ b/t/01-backends_status.t
@@ -1,0 +1,146 @@
+#!/usr/bin/perl
+# This program is open source, licensed under the PostgreSQL License.
+# For license terms, see the LICENSE file.
+#
+# Copyright (C) 2012-2022: Open PostgreSQL Monitoring Development Group
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+use pgNode;
+use pgSession;
+use TestLib ();
+use IPC::Run ();
+use Test::More;
+
+my $node = pgNode->get_new_node('prod');
+my @timer;
+my @in;
+my @out;
+my @procs;
+my @stdout;
+
+$node->init;
+$node->append_conf('postgresql.conf', 'max_connections=8');
+$node->start;
+
+### Beginning of tests ###
+
+# basic check without thresholds
+$node->command_checks_all( [
+    './check_pgactivity', '--service'  => 'backends_status',
+                          '--username' => getlogin,
+                          '--format'   => 'human'
+    ],
+    0,
+    [ qr/^Service  *: POSTGRES_BACKENDS_STATUS$/m,
+      qr/^Returns  *: 0 \(OK\)$/m,
+    ],
+    [ qr/^$/ ],
+    'OK without thresholds'
+);
+
+# basic check with thresholds
+$node->command_checks_all( [
+    './check_pgactivity', '--service'  => 'backends_status',
+                          '--username' => getlogin,
+                          '--format'   => 'human',
+                          '--dbname'   => 'template1',
+                          '--warning'  => 'idle_xact=4s',
+                          '--critical' => 'idle_xact=5s'
+    ],
+    0,
+    [
+      qr/^Service  *: POSTGRES_BACKENDS_STATUS$/m,
+      qr/^Returns  *: 0 \(OK\)$/m,
+      qr/^Message  *: 1 backend connected$/m,
+      qr/^Perfdata *: active=1$/m,
+      qr/^Perfdata *: oldest active=0s$/m,
+      qr/^Perfdata *: disabled=0$/m,
+      qr/^Perfdata *: fastpath function call=0$/m,
+      qr/^Perfdata *: oldest fastpath function call=0s$/m,
+      qr/^Perfdata *: idle=0$/m,
+      qr/^Perfdata *: oldest idle=0s$/m,
+      qr/^Perfdata *: idle in transaction=0$/m,
+      qr/^Perfdata *: oldest idle in transaction=0s warn=4s crit=5s min=\d max=\d$/m,
+      qr/^Perfdata *: idle in transaction \(aborted\)=0$/m,
+      qr/^Perfdata *: oldest idle in transaction \(aborted\)=0s$/m,
+      qr/^Perfdata *: insufficient privilege=0$/m,
+      qr/^Perfdata *: undefined=0$/m,
+      qr/^Perfdata *: waiting for lock=0$/m,
+      qr/^Perfdata *: oldest waiting for lock=0s$/m,
+    ],
+    [ qr/^$/ ],
+    'basic check with threshold and check presence of all perfdata'
+);
+
+# two sessions on two different db
+
+TestLib::system_or_bail('createdb',
+    '--host' => $node->host,
+    '--port' => $node->port,
+    'testdb'
+);
+
+push @procs, pgSession->new($node, 'testdb') for 1..3;
+
+$procs[0]->query('select pg_sleep(60)', 60);
+$procs[1]->query('BEGIN',0);
+
+# wait for backend to be connected and active
+$node->poll_query_until('template1', q{
+    SELECT query_start IS NOT NULL -- < now()
+    FROM pg_catalog.pg_stat_activity
+    WHERE datname = 'testdb'
+    LIMIT 1
+});
+
+$node->command_checks_all( [
+    './check_pgactivity', '--service'  => 'backends_status',
+                          '--username' => getlogin,
+                          '--format'   => 'human',
+                          '--dbname'   => 'template1',
+                          '--warning'  => 'active=3',
+                          '--critical' => 'active=4'
+    ],
+    0,
+    [ qr/^Service  *: POSTGRES_BACKENDS_STATUS$/m,
+      qr/^Returns  *: 0 \(OK\)$/m,
+      qr/^Message  *: 4 backend connected$/m,
+      qr/^Perfdata *: idle=1$/m,
+      qr/^Perfdata *: idle in transaction=1$/m,
+      qr/^Perfdata *: active=2 warn=3 crit=4 min=\d max=\d$/m,
+    ],
+    [ qr/^$/ ],
+    'three sessions, one active, one idlexact, one idle, OK'
+);
+
+$node->command_checks_all( [
+    './check_pgactivity', '--service'  => 'backends_status',
+                          '--username' => getlogin,
+                          '--format'   => 'human',
+                          '--dbname'   => 'template1',
+                          '--warning'  => 'active=1',
+                          '--critical' => 'active=2'
+    ],
+    2,
+    [ qr/^Service  *: POSTGRES_BACKENDS_STATUS$/m,
+      qr/^Returns  *: 2 \(CRITICAL\)$/m,
+      qr/^Message  *: 2 active$/m,
+      qr/^Perfdata *: idle=1$/m,
+      qr/^Perfdata *: idle in transaction=1$/m,
+      qr/^Perfdata *: active=2 warn=1 crit=2 min=\d max=\d$/m,
+    ],
+    [ qr/^$/ ],
+    'three sessions, one active, one idlexact, one idle, Critical'
+);
+
+
+done_testing();
+exit;
+
+### End of tests ###
+
+# stop immediate to kill any remaining backends
+$node->stop('immediate');


### PR DESCRIPTION
Active backends with wait_event_type other then Active ou Client were not accounted as active.
Add a bit more debug output and a regression test for it.

Fix issue #345 