### PR TITLE
fix: temp_files on PG10-11 is counting data files as temp files

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -8520,22 +8520,30 @@ sub check_temp_files {
                  SUM(COALESCE((pg_stat_file(agg.dir||'/'||agg.tmpfile, true)).size, 0)) AS SIZE
             FROM ( SELECT ls.oid, ls.spcname AS spcname,
                           ls.dir||'/'||ls.sub AS dir,
-                          pg_ls_dir(ls.dir||'/'||ls.sub) AS tmpfile
-                     FROM ( SELECT sr.oid, sr.spcname,
+                          tmpdir.tmpfile
+                     FROM ( SELECT * FROM  (
+                               SELECT sr.oid, sr.spcname,
                                    'pg_tblspc/'||sr.oid||'/'||sr.spc_root AS dir,
                                    pg_ls_dir('pg_tblspc/'||sr.oid||'/'||sr.spc_root) AS sub
-                              FROM ( SELECT spc.oid, spc.spcname,
+                                FROM ( SELECT spc.oid, spc.spcname,
                                             pg_ls_dir('pg_tblspc/'||spc.oid) AS spc_root,
                                             trim(TRAILING e'\n ' FROM pg_read_file('PG_VERSION')) AS v
                                        FROM ( SELECT oid, spcname
                                                 FROM pg_tablespace
-                                               WHERE spcname !~ '^pg_' ) AS spc ) sr
-                             WHERE sr.spc_root ~ ('^PG_'||sr.v)
+                                               WHERE spcname !~ '^pg_'
+                                            ) AS spc
+                                      ) sr
+                               WHERE sr.spc_root ~ ('^PG_'||sr.v)
+                             ) tmpr
+                             WHERE tmpr.sub = 'pgsql_tmp'
                              UNION ALL
-                 SELECT 0, 'pg_default', 'base' AS dir, 'pgsql_tmp' AS sub
-                               FROM pg_ls_dir('base') AS l
-                              WHERE l='pgsql_tmp'
-              ) AS ls
+                             SELECT 0, 'pg_default', 'base' AS dir, 'pgsql_tmp' AS sub
+                             FROM pg_ls_dir('base') AS l
+                             WHERE l='pgsql_tmp'
+                            ) AS ls
+                          LEFT OUTER JOIN LATERAL (
+                            SELECT pg_ls_dir(ls.dir||'/'||ls.sub) AS tmpfile
+                            ) AS tmpdir ON (true)
                  ) AS agg
            WHERE current_setting('is_superuser')::bool
            GROUP BY 1, 2

--- a/t/01-temp-files.t
+++ b/t/01-temp-files.t
@@ -1,0 +1,219 @@
+#!/usr/bin/perl
+# This program is open source, licensed under the PostgreSQL License.
+# For license terms, see the LICENSE file.
+#
+# Copyright (C) 2012-2022: Open PostgreSQL Monitoring Development Group
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+use pgNode;
+use pgSession;
+use File::Path qw(rmtree);
+use Test::More tests => 39;
+
+my $node = pgNode->get_new_node('prod');
+my $proc;
+
+$node->init;
+$node->start;
+
+### Beginning of tests ###
+
+# This service can run without thresholds
+
+# Tests for PostreSQL 8.1 and before
+SKIP: {
+    skip "testing incompatibility with PostgreSQL 8.1 and before", 3
+        if $node->version >= 8.2;
+
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'temp_files',
+                              '--username' => getlogin,
+                              '--format'   => 'human',
+        ],
+        1,
+        [ qr/^$/ ],
+        [ qr/^Service temp_files is not compatible with host/ ],
+        'non compatible PostgreSQL version'
+    );
+}
+
+SKIP: {
+    skip "incompatible tests with PostgreSQL < 8.2", 34 if $node->version < 8.2;
+
+    # basic check
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'temp_files',
+                              '--username' => getlogin,
+                              '--format'   => 'human',
+                              '--dbname'   => 'template1',
+        ],
+        0,
+        [ qr/^Service  *: POSTGRES_TEMP_FILES$/m,
+          qr/^Returns  *: 0 \(OK\)$/m,
+          qr/^Message  *: 3 tablespace\(s\)\/database\(s\) checked$/m,
+        ],
+        [ qr/^$/ ],
+        'basic check'
+    );
+    sleep 2;
+
+    $proc = pgSession->new( $node, 'postgres' );
+
+    # unit test OK
+    $proc->query('SELECT random() * x FROM generate_series(1,1000000) AS F(x) ORDER BY 1;', 2);
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'temp_files',
+                              '--username' => getlogin,
+                              '--format'   => 'human',
+                              '--dbname'   => 'template1',
+                              '--warning'  => '3',
+                              '--critical' => '4'
+        ],
+        0,
+        [ qr/^Service  *: POSTGRES_TEMP_FILES$/m,
+          qr/^Returns  *: 0 \(OK\)$/m,
+          qr/^Message  *: 4 tablespace\(s\)\/database\(s\) checked$/m,
+          qr/^Perfdata *: # files in pg_default=.*File warn=3 crit=4$/m,
+          qr/^Perfdata *: Total size in pg_default=.*$/m,
+          qr/^Perfdata *: postgres=.*Fpm$/m,
+          qr/^Perfdata *: postgres=.*Bpm$/m,
+          qr/^Perfdata *: postgres=.*Files warn=3 crit=4$/m,
+          qr/^Perfdata *: postgres=.*B$/m,
+          qr/^Perfdata *: template1=0Fpm$/m,
+          qr/^Perfdata *: template1=0Bpm$/m,
+          qr/^Perfdata *: template1=0Files warn=3 crit=4$/m,
+          qr/^Perfdata *: template1=0B$/m,
+          qr/^Perfdata *: template0=0Fpm$/m,
+          qr/^Perfdata *: template0=0Bpm$/m,
+          qr/^Perfdata *: template0=0Files warn=3 crit=4$/m,
+          qr/^Perfdata *: template0=0B$/m,
+        ],
+        [ qr/^$/ ],
+        'test OK'
+    );
+    sleep 2;
+
+    # unit test WARN
+    $proc->query('SELECT random() * x FROM generate_series(1,1000000) AS F(x) ORDER BY 1;', 2);
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'temp_files',
+                              '--username' => getlogin,
+                              '--format'   => 'human',
+                              '--dbname'   => 'template1',
+                              '--warning'  => '1',
+                              '--critical' => '3'
+        ],
+        1,
+        [ qr/^Service  *: POSTGRES_TEMP_FILES$/m,
+          qr/^Returns  *: 1 \(WARNING\)$/m,
+          qr/^Message  *: pg_default \(.* file\(s\)\/.*\)$/m,
+          qr/^Message  *: postgres \(.* file\(s\)\/.*\)$/m,
+          qr/^Perfdata *: # files in pg_default=.*File warn=1 crit=3$/m,
+          qr/^Perfdata *: Total size in pg_default=.*$/m,
+          qr/^Perfdata *: postgres=.*Fpm$/m,
+          qr/^Perfdata *: postgres=.*Bpm$/m,
+          qr/^Perfdata *: postgres=.*Files warn=1 crit=3$/m,
+          qr/^Perfdata *: postgres=.*B$/m,
+          qr/^Perfdata *: template1=0Fpm$/m,
+          qr/^Perfdata *: template1=0Bpm$/m,
+          qr/^Perfdata *: template1=0Files warn=1 crit=3$/m,
+          qr/^Perfdata *: template1=0B$/m,
+          qr/^Perfdata *: template0=0Fpm$/m,
+          qr/^Perfdata *: template0=0Bpm$/m,
+          qr/^Perfdata *: template0=0Files warn=1 crit=3$/m,
+          qr/^Perfdata *: template0=0B$/m,
+        ],
+        [ qr/^$/ ],
+        'test WARN'
+    );
+    sleep 2;
+
+    # unit test CRIT
+    $proc->query('SELECT random() * x FROM generate_series(1,1000000) AS F(x) ORDER BY 1;', 2);
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'temp_files',
+                              '--username' => getlogin,
+                              '--format'   => 'human',
+                              '--dbname'   => 'template1',
+                              '--warning'  => '0',
+                              '--critical' => '1'
+        ],
+        2,
+        [ qr/^Service  *: POSTGRES_TEMP_FILES$/m,
+          qr/^Returns  *: 2 \(CRITICAL\)$/m,
+          qr/^Message  *: pg_default \(.* file\(s\)\/.*\)$/m,
+          qr/^Message  *: postgres \(.* file\(s\)\/.*\)$/m,
+          qr/^Perfdata *: # files in pg_default=.*File warn=0 crit=1$/m,
+          qr/^Perfdata *: Total size in pg_default=.*$/m,
+          qr/^Perfdata *: postgres=.*Fpm$/m,
+          qr/^Perfdata *: postgres=.*Bpm$/m,
+          qr/^Perfdata *: postgres=.*Files warn=0 crit=1$/m,
+          qr/^Perfdata *: postgres=.*B$/m,
+          qr/^Perfdata *: template1=0Fpm$/m,
+          qr/^Perfdata *: template1=0Bpm$/m,
+          qr/^Perfdata *: template1=0Files warn=0 crit=1$/m,
+          qr/^Perfdata *: template1=0B$/m,
+          qr/^Perfdata *: template0=0Fpm$/m,
+          qr/^Perfdata *: template0=0Bpm$/m,
+          qr/^Perfdata *: template0=0Files warn=0 crit=1$/m,
+          qr/^Perfdata *: template1=0B$/m,
+        ],
+        [ qr/^$/ ],
+        'test CRIT'
+    );
+    sleep 2;
+
+    # unit test with a TS
+    # * are the temfile located in the correct directory ?
+    # * do we only account for temp files ? (cf issue #351)
+    mkdir $node->basedir . '/tablespace1';
+    $node->psql('postgres', 'CREATE TABLESPACE myts1 LOCATION \'' . $node->basedir . '/tablespace1\';');
+    mkdir $node->basedir . '/tablespace2';
+    $node->psql('postgres', 'CREATE TABLESPACE myts2 LOCATION \'' . $node->basedir . '/tablespace2\';');
+
+    $node->psql('postgres', 'CREATE TABLE matable0(x text);');
+    $node->psql('postgres', 'CREATE TABLE matable1(x text) TABLESPACE myts1;');
+    $node->psql('postgres', 'CREATE TABLE matable2(x text) TABLESPACE myts2;');
+    $node->psql('postgres', 'VACUUM;');
+
+    $proc->query('SET temp_tablespaces TO myts2;');
+    $proc->query('SELECT random() * x FROM generate_series(1,1000000) AS F(x) ORDER BY 1;', 2);
+
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'temp_files',
+                              '--username' => getlogin,
+                              '--format'   => 'human',
+                              '--dbname'   => 'template1',
+        ],
+        0,
+        [ qr/^Service  *: POSTGRES_TEMP_FILES$/m,
+          qr/^Returns  *: 0 \(OK\)$/m,
+          qr/^Message  *: 4 tablespace\(s\)\/database\(s\) checked$/m,
+          qr/^Perfdata *: # files in myts2=.*File$/m,
+          qr/^Perfdata *: postgres=.*Fpm$/m,
+          qr/^Perfdata *: Total size in myts2=.*$/m,
+          qr/^Perfdata *: postgres=.*Fpm$/m,
+          qr/^Perfdata *: postgres=.*Bpm$/m,
+          qr/^Perfdata *: postgres=.*Files$/m,
+          qr/^Perfdata *: postgres=.*B$/m,
+          qr/^Perfdata *: template1=0Fpm$/m,
+          qr/^Perfdata *: template1=0Bpm$/m,
+          qr/^Perfdata *: template1=0Files$/m,
+          qr/^Perfdata *: template1=0B$/m,
+          qr/^Perfdata *: template0=0Fpm$/m,
+          qr/^Perfdata *: template0=0Bpm$/m,
+          qr/^Perfdata *: template0=0Files$/m,
+          qr/^Perfdata *: template0=0B$/m,
+        ],
+        [ qr/^$/ ],
+        'test with ts'
+    );
+}
+
+### End of tests ###
+
+# stop immediate to kill any remaining backends
+$node->stop( 'immediate' );


### PR DESCRIPTION
Closes #350

Restore the filter on pgsql_tmp directory lost in the v10 adaptation,
which lead to wrong results when tablespaces are present.

The last pg_ls_dir is transformed as a OUTER JOIN LATERAL
to keep the line of tablespaces without lines, like in 9.6.

As a by product, pg_default is always listed as a tablespace again.

Before (with a running query, a few tablespaces):
```
$ /opt/check_pgactivity/check_pgactivity --status-file=/tmp/sdfdsf -s temp_files  --dbservice  nagios_defo10

POSTGRES_TEMP_FILES OK: 18 tablespace(s)/database(s) checked | '# files in test 2'=1File 'Total size in test 2'=0B '# files in untbl'=2300File 'Total size in untbl'=178224263B '# files in pg_default'=2File 'Total size in pg_default'=167377664B '# files in test'=1File 'Total size in test'=0B postgres=3.33333333333333Fpm postgres=467133013.333333Bpm postgres=2Files postgres=280279808B pgbench=0Fpm pgbench=0Bpm pgbench=0Files pgbench=0B template1=0Fpm template1=0Bpm template1=0Files template1=0B template0=0Fpm template0=0Bpm template0=0Files template0=0B ...
```

After : 
```
$ /opt/check_pgactivity/check_pgactivity --status-file=/tmp/sdfdsf2 -s temp_files  --dbservice  nagios_defo10

POSTGRES_TEMP_FILES OK: 18 tablespace(s)/database(s) checked | '# files in test 2'=0File 'Total size in test 2'=0B '# files in untbl'=0File 'Total size in untbl'=0B '# files in pg_default'=2File 'Total size in pg_default'=280279808B '# files in test'=0File 'Total size in test'=0B postgres=0Fpm postgres=0Bpm postgres=0Files postgres=0B pgbench=0Fpm pgbench=0Bpm pgbench=0Files pgbench=0B template1=0Fpm template1=0Bpm template1=0Files template1=0B template0=0Fpm template0=0Bpm template0=0Files template0=0B ...
```


With a running query and `temp_tablespace = untbl` :
```
$ /opt/check_pgactivity/check_pgactivity --status-file=/tmp/sdfdsf2 -s temp_files  --dbservice  nagios_defo10

POSTGRES_TEMP_FILES OK: 18 tablespace(s)/database(s) checked | '# files in test 2'=0File 'Total size in test 2'=0B '# files in untbl'=2File 'Total size in untbl'=210942720B '# files in pg_default'=0File 'Total size in pg_default'=0B '# files in test'=0File 'Total size in test'=0B postgres=0Fpm postgres=0Bpm postgres=0Files postgres=0B pgbench=0Fpm pgbench=0Bpm pgbench=0Files pgbench=0B template1=0Fpm template1=0Bpm template1=0Files template1=0B template0=0Fpm template0=0Bpm template0=0Files template0=0B ....
``` 