### PR TITLE
stat_snapshot_age valid for 9.5 => 14

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -7586,7 +7586,7 @@ SELECT
     return status_ok( $me, \@msg, \@perfdata );
 }
 
-=item B<stat_snapshot_age> (9.5+)
+=item B<stat_snapshot_age> (9.5 to 14 included)
 
 Check the age of the statistics snapshot (statistics collector's statistics).
 This probe helps to detect a frozen stats collector process.
@@ -7629,7 +7629,7 @@ sub check_stat_snapshot_age {
         -exitval => 127
     ) if @hosts != 1;
 
-    is_compat $hosts[0], 'stat_snapshot_age', $PG_VERSION_95 or exit 1;
+    is_compat $hosts[0], 'stat_snapshot_age', $PG_VERSION_95, $PG_VERSION_140 or exit 1;
 
     @rs = @{ query ( $hosts[0], $query ) };
 


### PR DESCRIPTION
This check aimed to detect a staled stats collector that happened sometimes before release 15. It's useless for pg 15+. This patch adds a check for this and updates the documentation (See #352). 