### PR TITLE
Ignore partition table in check_last_maintenance

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -5053,9 +5053,11 @@ sub check_last_maintenance {
                   FROM pg_catalog.pg_stat_database
                   WHERE datname = current_database()
                 )
-            FROM pg_stat_user_tables
+            FROM pg_stat_user_tables a
+            JOIN pg_class b on a.relid = b.oid
             WHERE schemaname NOT LIKE 'pg_temp_%'
               AND schemaname NOT LIKE 'pg_toast_temp_%'
+              AND relkind <> 'p' -- partitioned table do not have last_* information
         }
     );
 


### PR DESCRIPTION
Partitioned tables are empty, thus last_* are null.

Fix https://github.com/OPMDG/check_pgactivity/issues/365