### PR TITLE
Adds the hugepages service

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -285,6 +285,10 @@ my %services = (
         'sub'  => \&check_pgdata_permission,
         'desc' => 'Check that the permission on PGDATA is 700.'
     },
+    'hugepages' => {
+        'sub'  => \&check_hugepages,
+        'desc' => 'Check if the hugepages are in the expected state.'
+    },
     'uptime' => {
         'sub'  => \&check_uptime,
         'desc' => 'Time since postmaster start or configurtion reload.'
@@ -496,7 +500,8 @@ my %args = (
     'dump-status-file'      => 0,
     'dump-bin-file'         => undef,
     'format'                => 'nagios',
-    'uid'                   => undef
+    'uid'                   => undef,
+    'with-hugepages'        => undef
 );
 
 # Set name of the program without path*
@@ -2311,6 +2316,7 @@ sub check_autovacuum {
     return status_ok( $me, \@msg , \@perfdata, \@longmsg );
 
 }
+
 
 =item B<backends> (all)
 
@@ -8788,6 +8794,51 @@ DB_LOOP: foreach my $stat (@rs) {
 }
 
 
+=item B<hugepages> (17+)
+
+Checks if the hupepages are in the expected state:
+  * unused: the default
+  * used: if C<--with-hugepages> is specified
+
+The perfdata returns the status where 0 is off, 1 is on and 2 is unknown.
+
+=cut
+
+sub check_hugepages {
+
+    my @rs;
+    my @perfdata;
+    my @hosts;
+    my %args         = %{ $_[0] };
+    my $me           = 'POSTGRES_HUGEPAGES';
+    my $hp_setting   = ( defined( $args{'with-hugepages'} ) ? 'on' : 'off' );
+    my $sql          = q{
+        SELECT setting as huge_pages_status,
+               CASE WHEN setting = 'off'     THEN 0
+                    WHEN setting = 'on'      THEN 1
+                    WHEN setting = 'unknown' THEN 2
+               END as huge_pages_status_code
+          FROM pg_settings WHERE name = 'huge_pages_status'
+    };
+
+    @hosts = @{ parse_hosts %args };
+
+    pod2usage(
+        -message => 'FATAL: you must give only one host with service "hugepages".',
+        -exitval => 127
+    ) if @hosts != 1;
+
+    is_compat $hosts[0], 'hugepages', $PG_VERSION_170 or exit 1;
+
+    @rs = @{ query( $hosts[0], $sql) };
+    push @perfdata => [ "huge_page_status", $rs[0][1] ];
+
+    return status_critical( $me, [ "The huge pages are: $rs[0][0], the expected state was: $hp_setting." ], \@perfdata )
+        if $rs[0][0] ne $hp_setting;
+
+    return status_ok( $me, [ "The huge pages are in the expected state: $hp_setting." ], \@perfdata );
+}
+
 =item B<uptime> (8.1+)
 
 Returns time since postmaster start ("uptime", from 8.1),
@@ -9262,6 +9313,7 @@ GetOptions(
         'global-pattern=s',
         'help|?!',
         'host|h=s',
+        'with-hugepages!',
         'ignore-wal-size!',
         'unarchiver=s',
         'dbname|d=s',

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -8796,10 +8796,10 @@ DB_LOOP: foreach my $stat (@rs) {
 
 =item B<hugepages> (17+)
 
-Checks if the hupe pages are in use.
+Check whether huge pages are in use.
 
 The default is to expect the huge pages to be unused, if C<--with-hugepages> is
-specified the service expect them to be in use.
+specified the service expects them to be in use.
 
 The perfdata returns the status where 0 is off, 1 is on and 2 is unknown.
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -8796,10 +8796,10 @@ DB_LOOP: foreach my $stat (@rs) {
 
 =item B<hugepages> (17+)
 
-Checks if the hupepages are in the expected state:
+Checks if the hupe pages are in use.
 
-  * unused: the default
-  * used: if C<--with-hugepages> is specified
+The default is to expect the huge pages to be unused, if C<--with-hugepages> is
+specified the service expect them to be in use.
 
 The perfdata returns the status where 0 is off, 1 is on and 2 is unknown.
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -8797,6 +8797,7 @@ DB_LOOP: foreach my $stat (@rs) {
 =item B<hugepages> (17+)
 
 Checks if the hupepages are in the expected state:
+
   * unused: the default
   * used: if C<--with-hugepages> is specified
 

--- a/t/01-hugepages.t
+++ b/t/01-hugepages.t
@@ -1,0 +1,82 @@
+#!/usr/bin/perl
+# This program is open source, licensed under the PostgreSQL License.
+# For license terms, see the LICENSE file.
+#
+# Copyright (C) 2012-2023: Open PostgreSQL Monitoring Development Group
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+use pgNode;
+use pgSession;
+use Time::HiRes qw(usleep gettimeofday tv_interval);
+use Test::More tests => 143;
+
+my $node = pgNode->get_new_node('prod');
+
+$node->init;
+$node->start;
+
+### Beginning of tests ###
+
+# This service can run without thresholds
+
+# Tests for PostreSQL 16 and before
+SKIP: {
+    skip "testing incompatibility with PostgreSQL 16 and before", 3
+        if $node->version >= 17;
+
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'hugepages',
+                              '--username' => getlogin,
+                              '--format'   => 'human',
+        ],
+        1,
+        [ qr/^$/ ],
+        [ qr/^Service hugepages is not compatible with host/ ],
+        'non compatible PostgreSQL version'
+    );
+}
+
+SKIP: {
+    skip "incompatible tests with PostgreSQL < 17", 34 if $node->version < 17;
+
+    # basic check => Returns OK
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'hugepages',
+                              '--username' => getlogin,
+                              '--format'   => 'human',
+        ],
+        0,
+        [ qr/^Service  *: POSTGRES_HUGEPAGES$/m,
+          qr/^Returns  *: 0 \(OK\)$/m,
+          qr/^Message  *: The huge pages are in the expected state: off.$/m,
+          qr/^Perfdata *: huge_page_status=0$/m,
+        ],
+        [ qr/^$/ ],
+        'basic check'
+    );
+
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'hugepages',
+                              '--username' => getlogin,
+                              '--format'   => 'human',
+                              '--with-hugepages',
+        ],
+        2,
+        [ qr/^Service  *: POSTGRES_HUGEPAGES$/m,
+          qr/^Returns  *: 2 \(CRITICAL\)$/m,
+          qr/^Message  *: The huge pages are: off, the expected state was: on.$/m,
+          qr/^Perfdata *: huge_page_status=0$/m,
+        ],
+        [ qr/^$/ ],
+        'failed check'
+    );
+}
+
+### End of tests ###
+
+# stop immediate to kill any remaining backends
+$node->stop( 'immediate' );
+


### PR DESCRIPTION
PG17 added a guc `huge_page_status` to show the allocation state of huge pages when setting up a server with `huge_pages = try`. This MR add a service to check this guc cf (#296).

https://git.postgresql.org/gitweb/?p=postgresql.git;a=commitdiff;h=a14354cac