### PR TITLE
Fix annoying race condition in archiver service

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -2026,7 +2026,7 @@ sub check_archiver {
                         (pg_stat_file('pg_wal/'||pg_walfile_name(
                            (to_hex((last_archived_off+1)/4294967296)
                            ||'/'||to_hex((last_archived_off+1)%4294967296))::pg_lsn
-                      ))).modification ))
+                      ), true)).modification ))
                  WHERE current_setting('is_superuser')::bool
                 ) AS oldest
         FROM (
@@ -2093,7 +2093,7 @@ sub check_archiver {
                     (pg_stat_file('pg_wal/'||pg_walfile_name(
                         (to_hex((last_archived_off+1)/4294967296)
                         ||'/'||to_hex((last_archived_off+1)%4294967296))::pg_lsn
-                    ))).modification )
+                    ), true)).modification )
                 ) AS oldest
         FROM (
             SELECT last_archived_wal, last_archived_time, last_failed_wal,


### PR DESCRIPTION
Function pg_current_wal_lsn() can return a LSN right at the begining of a new WAL segment, like XX/YY000000. Also, archiver service query always tries to check for how long the next segment exists using pg_stat_file(). No matter if it is waiting for archiver or the actual current WAL.

However, pointing to XX/YY000000 doesn't mean the WAL already exists if no write occurs to actualy create the WAL. This leads to annoying UNKNOWN status with the following error:

  Info:    CHECK_PGACTIVITY UNKNOWN: Query failed !
  ERROR:  could not stat file "pg_wal/000000010000076500000095":
          No such file or directory

Function pg_stat_file() can ignore missing file since 9.5, so just ignore and report 0s, which is actually what we already do anyway when no WAL are waiting to archive.