### PR TITLE
Fix typo in script argment (timemout -> timeout)

### DIFF
--- a/README
+++ b/README
@@ -2,7 +2,7 @@ NAME
     check_pgactivity - PostgreSQL plugin for Nagios
 
 SYNOPSIS
-      check_pgactivity {-w|--warning THRESHOLD} {-c|--critical THRESHOLD} [-s|--service SERVICE ] [-h|--host HOST] [-U|--username ROLE] [-p|--port PORT] [-d|--dbname DATABASE] [-S|--dbservice SERVICE_NAME] [-P|--psql PATH] [--debug] [--status-file FILE] [--path PATH] [-t|--timemout TIMEOUT]
+      check_pgactivity {-w|--warning THRESHOLD} {-c|--critical THRESHOLD} [-s|--service SERVICE ] [-h|--host HOST] [-U|--username ROLE] [-p|--port PORT] [-d|--dbname DATABASE] [-S|--dbservice SERVICE_NAME] [-P|--psql PATH] [--debug] [--status-file FILE] [--path PATH] [-t|--timeout TIMEOUT]
       check_pgactivity [-l|--list]
       check_pgactivity [--help]
 

--- a/README.pod
+++ b/README.pod
@@ -4,7 +4,7 @@ check_pgactivity - PostgreSQL plugin for Nagios
 
 =head1 SYNOPSIS
 
-  check_pgactivity {-w|--warning THRESHOLD} {-c|--critical THRESHOLD} [-s|--service SERVICE ] [-h|--host HOST] [-U|--username ROLE] [-p|--port PORT] [-d|--dbname DATABASE] [-S|--dbservice SERVICE_NAME] [-P|--psql PATH] [--debug] [--status-file FILE] [--path PATH] [-t|--timemout TIMEOUT]
+  check_pgactivity {-w|--warning THRESHOLD} {-c|--critical THRESHOLD} [-s|--service SERVICE ] [-h|--host HOST] [-U|--username ROLE] [-p|--port PORT] [-d|--dbname DATABASE] [-S|--dbservice SERVICE_NAME] [-P|--psql PATH] [--debug] [--status-file FILE] [--path PATH] [-t|--timeout TIMEOUT]
   check_pgactivity [-l|--list]
   check_pgactivity [--help]
 

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -10,7 +10,7 @@ check_pgactivity - PostgreSQL plugin for Nagios
 
 =head1 SYNOPSIS
 
-  check_pgactivity {-w|--warning THRESHOLD} {-c|--critical THRESHOLD} [-s|--service SERVICE ] [-h|--host HOST] [-U|--username ROLE] [-p|--port PORT] [-d|--dbname DATABASE] [-S|--dbservice SERVICE_NAME] [-P|--psql PATH] [--debug] [--status-file FILE] [--path PATH] [-t|--timemout TIMEOUT]
+  check_pgactivity {-w|--warning THRESHOLD} {-c|--critical THRESHOLD} [-s|--service SERVICE ] [-h|--host HOST] [-U|--username ROLE] [-p|--port PORT] [-d|--dbname DATABASE] [-S|--dbservice SERVICE_NAME] [-P|--psql PATH] [--debug] [--status-file FILE] [--path PATH] [-t|--timeout TIMEOUT]
   check_pgactivity [-l|--list]
   check_pgactivity [--help]
 


### PR DESCRIPTION
Thanks for this lovely monitoring script.
We began using it today to monitor our psql instances.

This PR fix a typo with the timeout argument.
