### PR TITLE
bgwriter: PG17-compatible query from pgcluu

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -3002,6 +3002,30 @@ sub check_bgwriter {
               buffers_backend_fsync,
               extract ('epoch' from stats_reset)
             FROM pg_stat_bgwriter;
+        },
+        # Some columns were moved & renamed in PG17 from pg_stat_bgwriter
+        # to pg_stat_checkpointer (commit 96f052613f35d07d001c8dd2f284ca8d95f82d1b)
+        # & pg_stat_io (commit 74604a37f)
+        # This query is a hack to avoid to change too many things
+        $PG_VERSION_170 => q{WITH ioagg AS (
+                SELECT  sum(writes*op_bytes)    AS buff_backends,
+                        coalesce(sum(fsyncs),0) AS backend_fsync,
+                        current_setting('block_size')::numeric AS bs
+                FROM pg_stat_io
+                WHERE object='relation'
+                AND backend_type IN ('client backend','autovacuum worker')
+              )
+            SELECT
+                c.num_timed            AS checkpoints_timed,
+                c.num_requested        AS checkpoints_req,
+                c.buffers_written * bs AS buff_checkpoint,
+                b.buffers_clean   * bs AS buff_clean,
+                b.maxwritten_clean,
+                ioagg.buff_backends,
+                b.buffers_alloc * bs   AS buff_alloc,
+                ioagg.backend_fsync,
+                extract ('epoch' from b.stats_reset)
+            FROM pg_stat_bgwriter b, pg_stat_checkpointer c, ioagg ;
         }
     );
 


### PR DESCRIPTION
Solves: #373 

The query rebuilds the former `pg_stat_bgwriter` results with `pg_stat_checkpointer` and some of the `pg_stat_io` lines.

This is a modified version from my patch for pgcluu: https://github.com/darold/pgcluu/pull/178

I don't claim to understand fully what's in `pg_stat_io`, but the results seem similar enough for me.

* Exemple of results of the queries after a reset, pgbench -i -s 100 et  -s10, vacuumdb --freeze, one minute of pgbench each, a vacuum full of both, and some intermediate checkpoints:

PG16:
```
checkpoints_timed     | 0
checkpoints_req       | 5
?column?              | 261873664
?column?              | 499318784
maxwritten_clean      | 607
?column?              | 5228593152
?column?              | 5078130688
buffers_backend_fsync | 0
extract               | 1759751521.058037
```

PG17:
```
checkpoints_timed | 0
checkpoints_req   | 5
buff_checkpoint   | 261357568
buff_clean        | 473538560
maxwritten_clean  | 572
buff_backends     | 5052678144
buff_alloc        | 3850584064
backend_fsync     | 0
extract           | 1759751859.963304
```