### PR TITLE
New query for v18 in check_bgwriter

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -3030,6 +3030,28 @@ sub check_bgwriter {
                 ioagg.backend_fsync,
                 extract ('epoch' from b.stats_reset)
             FROM pg_stat_bgwriter b, pg_stat_checkpointer c, ioagg ;
+        },
+        # Some columns were changed from pg_stat_io in PG18
+        # writes became write_bytes, and op_bytes was removed
+        $PG_VERSION_180 => q{WITH ioagg AS (
+                SELECT  sum(write_bytes)    AS buff_backends,
+                        coalesce(sum(fsyncs),0) AS backend_fsync,
+                        current_setting('block_size')::numeric AS bs
+                FROM pg_stat_io
+                WHERE object='relation'
+                AND backend_type IN ('client backend','autovacuum worker')
+              )
+            SELECT
+                c.num_timed            AS checkpoints_timed,
+                c.num_requested        AS checkpoints_req,
+                c.buffers_written * bs AS buff_checkpoint,
+                b.buffers_clean   * bs AS buff_clean,
+                b.maxwritten_clean,
+                ioagg.buff_backends,
+                b.buffers_alloc * bs   AS buff_alloc,
+                ioagg.backend_fsync,
+                extract ('epoch' from b.stats_reset)
+            FROM pg_stat_bgwriter b, pg_stat_checkpointer c, ioagg ;
         }
     );
 


### PR DESCRIPTION
Some columns were changed from pg_stat_io in PG18. writes became write_bytes, and op_bytes was removed.