### PR TITLE
Allow warnings from the settings service to expire

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -7771,17 +7771,15 @@ PARAM_LOOP: foreach my $row (@rs) {
     $expected_result = 2 if scalar @long_msg;   # Regular warning
     $expected_result = 1 if $pending_count > 0; # Pending restart
     $this_msg = join('\0', @long_msg);
-    if ( not defined $settings_laste{'date'} || not defined $settings_laste{'msg'}  ) {
-        $settings_laste{'msg'} = "";
-        $settings_laste{'date'} = $now;
-    }
+    $settings_lastemsg = $settings_laste{'msg'} // "";
+    $settings_lastedate = $settings_laste{'date'} // $now;
 
-    if ( $this_msg ne $settings_laste{'msg'} ) {
+    if ( $this_msg ne $settings_lastemsg ) {
         $settings_laste{'msg'} = $this_msg;
         $settings_laste{'date'} = $now;
         save $hosts[0], 'settings_laste', \%settings_laste, $args{'status-file'};
     } else {
-        my $duration = $now - $settings_laste{'date'};
+        my $duration = $now - $settings_lastedate;
 
         if ( defined $w_limit && $expected_result eq 2 && $duration >= $w_limit ) {
             # Should have been a warning but the warning treshold has expired.


### PR DESCRIPTION
With this patch Warning is raised when the time since configuration change
is less than the warning threshold. Obviously these alerts will disappear from
themselves once enough time has passed. This doesn't apply for configuration 
changes with pending restart warnings.

Eg:

```
./check_pgactivity -s settings -h /var/run/postgresql -p 5433  -w 1s
```

Closes #405
