### PR TITLE
last_maintenance: fix documentation

### DIFF
--- a/README
+++ b/README
@@ -738,8 +738,7 @@ COMPATIBILITY
 
     last_analyze (8.2+)
         Check on each databases that the oldest "analyze" (from autovacuum
-        or not) is not older than the given threshold. This is to check that
-        a scheduled ANALYZE is working correctly.
+        or not) is not older than the given threshold.
 
         This service uses the status file (see "--status-file" parameter)
         with PostgreSQL 9.1+.
@@ -777,8 +776,7 @@ COMPATIBILITY
 
     last_vacuum (8.2+)
         Check that the oldest vacuum (from autovacuum or otherwise) in each
-        database in the cluster is not older than the given threshold. This
-        is to check that a scheduled VACUUM is working correctly.
+        database in the cluster is not older than the given threshold.
 
         This service uses the status file (see "--status-file" parameter)
         with PostgreSQL 9.1+.


### PR DESCRIPTION
We are partially reverting c086240a90 because we changed our minds.

From the beginning, the code for this probe has considered `greatest(last_${type}, last_auto${type})`. Thus, the aim of this probe isn't to check that a scheduled VACUUM or ANALYZE is working correctly; it is to check that the table is processed in due time.