### PR TITLE
More perfdata, and a better message for oldest_idlexact

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -6982,6 +6982,8 @@ sub check_oldest_idlexact {
 
         $stats{$r->[0]} = {
             'num' => 0,
+            'numw' => 0,
+            'numc' => 0,
             'max' => -1,
             'avg' => 0,
         } unless exists $stats{$r->[0]};
@@ -6989,6 +6991,11 @@ sub check_oldest_idlexact {
         $oldest_idle = $r->[1] if $r->[1] > $oldest_idle;
 
         $stats{$r->[0]}{'num'}++ if $r->[1] > -1;
+        if ( $r->[1] > $c_limit ) {
+            $stats{$r->[0]}{'numc'}++;
+        } elsif ( $r->[1] > $w_limit ) {
+            $stats{$r->[0]}{'numw'}++;
+        }
         $stats{$r->[0]}{'max'} = $r->[1] if $stats{$r->[0]}{'max'} < $r->[1];
         $stats{$r->[0]}{'avg'} = (
             $stats{$r->[0]}{'avg'} * ($stats{$r->[0]}{'num'} -1) + $r->[1])
@@ -7010,16 +7017,18 @@ sub check_oldest_idlexact {
         push @perfdata, (
             [ "$db max", $stats{$db}{'max'}, 's', $w_limit, $c_limit ],
             [ "$db avg", $stats{$db}{'avg'}, 's', $w_limit, $c_limit ],
-            [ "$db # idle xact", $stats{$db}{'num'} ]
+            [ "$db # idle xact", $stats{$db}{'num'} ],
+            [ "$db # idle xact above warning", $stats{$db}{'numw'} ],
+            [ "$db # idle xact above critical", $stats{$db}{'numc'} ]
         );
 
         if ( $stats{$db}{'max'} > $c_limit ) {
-            push @msg => "oldest idle xact on $db: ". to_interval($stats{$db}{'max'});
+            push @msg => $stats{$db}{'numc'} ." above critical value, oldest idle xact on $db: ". to_interval($stats{$db}{'max'});
             next DB_LOOP;
         }
 
         if ( $stats{$db}{'max'} > $w_limit ) {
-            push @msg => "oldest idle xact on $db: ". to_interval($stats{$db}{'max'});
+            push @msg => $stats{$db}{'numw'} ." above warning value, oldest idle xact on $db: ". to_interval($stats{$db}{'max'});
         }
     }
 


### PR DESCRIPTION
The message now says how many idle transactions are older than the critical or warning value. Perfdata also adds this information.

Example:
$ ./check_pgactivity -s oldest_idlexact -F human --dbinclude demo -w 10s -c 300s
Service        : POSTGRES_OLDEST_IDLEXACT
Returns        : 1 (WARNING)
Message        : 5 idle transaction(s)
Message        : 1 above warning value, oldest idle xact on demo: 11s
Perfdata       : demo max=11.000000s warn=10 crit=300
Perfdata       : demo avg=11s warn=10 crit=300
Perfdata       : demo # idle xact=1
Perfdata       : demo # idle xact above warning=1
Perfdata       : demo # idle xact above critical=0

Fixes issue #348