### PR TITLE
Configuration difference

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -535,6 +535,7 @@ my %args = (
     'schexclude'            => undef,
     'relexclude'            => undef,
     'ok-on-standby'         => 0,
+    'identical'             => 0,
 );
 
 # Set name of the program without path*
@@ -3991,15 +3992,16 @@ LOOP: foreach my $setting (@rc) {
 =item B<configuration_difference>
 
 Check that the configuration is the same between two servers (according to pg_settings)
-By default, checks that the 1st server is a primary
-and the next one secondary that must be fully identical.
+By default, assumes that the 1st server is a primary
+and the others are secondaries that must be fully identical.
 
-Give the connection parameters with 2 or more services,
+Give the connections parameters with 2 or more services,
 eg. with --dbservices=pg1,pg2
 The first one is taken as the reference (usually a primary).
 
-By default it ignores archive_mode,primary_conninfo,primary_slot_name.
-Force the check with C<--identical>.
+By default it ignores a few parameters that will differ on a secondary:
+archive_mode,primary_conninfo,primary_slot_name.
+Force the check of all parameters with C<--identical>.
 
 This service supports the argument C<--exclude REGEX> to exclude parameters
 matching the expression. You can use multiple C<--exclude REGEX> arguments.
@@ -4007,21 +4009,19 @@ Eg : --exclude '(.*parallel.*|cluster_name|auto_explain.*|pg_stat_statements.*|w
 
 No perfdata
 
-Returns a Warning if some parameters are different.
+Returns a Warning if some parameters are different
 
 Required privileges: unprivileged role
 
-Known issues: roles configuration is ignored ;
-the connection role may hide the real configuration ;
-custom parameters (eg. demo.toto) are ignored if not declared by their extension.
+Known issues: roles configurations are ignored ;
+the connection role may hide the "real" configuration ;
+custom parameters (eg. demo.toto) cannot be checkd if not declared by their extension.
 
 =cut
 
 sub check_configuration_difference {
     my @perfdata;
     my @msg;
-    my @msg_crit;
-    my @msg_warn;
     my @hosts;
     my @cfg;
     my %refserver;
@@ -4032,8 +4032,9 @@ sub check_configuration_difference {
     my $mess            = "";
     my $setting_ref     = "";
     my @exclude_regexes = @{ $args{'exclude'} };
+    my $identical       = $args{'identical'} ;
     # will probably or always different on a primary & its secondary
-    my @ignored_if_secondary = ( 'archive_mode', 'in_hot_standby', 'primary_conninfo', 'primary_slot_name', '(transaction_read_only' ) ;
+    my @ignored_if_secondary = ( 'archive_mode', 'in_hot_standby', 'primary_conninfo', 'primary_slot_name', 'transaction_read_only' ) ;
     my $me              = 'POSTGRES_CONFIGURATION_DIFFERENCE';
     my %queries = (
         $PG_VERSION_74 => q{
@@ -4051,8 +4052,8 @@ sub check_configuration_difference {
     ) if @hosts < 2;
 
     # ignored parameters hash
-    %ignored = map { $_ => 1 } ( @ignored_if_secondary) ;
-    #if $args{'debug'} { foreach my $key (keys %ignored) { dprint "IGNORED: $key \n"; } };
+    if ( $identical ne 1 ) { %ignored = map { $_ => 1 } ( @ignored_if_secondary) } ;
+    foreach my $key (keys %ignored) { dprint "IGNORED: $key \n"; };
 
     # Fetch configuration for each host ; compare each parameter to the one on the 1st host a reference
     foreach my $host (@hosts) {
@@ -4070,6 +4071,7 @@ sub check_configuration_difference {
                 my ($name, $setting) = @$cfg;
                 dprint ("$host->{'dbservice'} : $name, $setting \n" ) ;
                 $setting_ref = ($refserver{$name}//'ABSENT') ;
+                # Parameter is different, not ignored, and not excluded by --exclude
                 if ( ( $setting ne $setting_ref) and not exists $ignored{$name} ) {
                     foreach my $exclude_regex ( @exclude_regexes ) {
                         next REC_PARAM if $name =~ /$exclude_regex/;
@@ -10280,6 +10282,7 @@ GetOptions(
         'unarchiver=s',
         'dbname|d=s',
         'dbservice|S=s',
+        'identical!',
         'list|l!',
         'maintenance_work_mem=i',
         'no_check_autovacuum!',
@@ -10397,6 +10400,12 @@ pod2usage(
     -message => 'FATAL: "detailed" argument is only allowed with "oldest_xmin" service.',
     -exitval => 127
 ) if scalar $args{'detailed'} and $args{'service'} ne 'oldest_xmin';
+
+# Check "check_difference" specific args --identical
+pod2usage(
+    -message => 'FATAL: "identical" argument is only allowed with "configuration_difference" service.',
+    -exitval => 127
+) if scalar $args{'identical'} and $args{'service'} ne 'configuration_difference';
 
 
 # Set psql absolute path

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -3991,7 +3991,7 @@ LOOP: foreach my $setting (@rc) {
 }
 
 
-=item B<configuration_difference>
+=item B<configuration_difference> (8.0+)
 
 Check that the configuration is the same between two servers (according to pg_settings)
 By default, assumes that the 1st server is a primary
@@ -4017,9 +4017,12 @@ Returns a Warning if some parameters are different
 
 Required privileges: unprivileged role
 
-Known issues: roles configurations are ignored ;
-the connection role may hide the "real" configuration ;
-custom parameters (eg. demo.toto) cannot be checkd if not declared by their extension.
+Known issues:
+TCP configuration can be checked only when two instances
+are connected by TCP (no socket);
+roles configurations are ignored;
+the connection role may hide the "real" configuration;
+custom parameters (eg. demo.foo) cannot be checked if not declared by their extension.
 
 =cut
 
@@ -4050,8 +4053,11 @@ sub check_configuration_difference {
     my @ignored_all = ('effective_wal_level');
     my $me          = 'POSTGRES_CONFIGURATION_DIFFERENCE';
     my %queries = (
-        $PG_VERSION_74 => q{
-        SELECT name, setting
+        $PG_VERSION_80 => q{
+        SELECT name,
+               (CASE WHEN name LIKE 'tcp%' AND inet_client_addr() IS NULL THEN 'N/A'
+                ELSE setting END
+               ) AS setting
         FROM pg_settings
         ORDER BY 1
         }
@@ -4072,6 +4078,7 @@ sub check_configuration_difference {
 
     # Fetch configuration for each host ; compare each parameter to the one on the 1st host a reference
     foreach my $host (@hosts) {
+        is_compat $hosts[$num_clusters], 'configuration', $PG_VERSION_80 or exit 1;
         $num_clusters ++;
         dprint ("Cluster $num_clusters : $host->{'dbservice'} \n" );
         # Fetch PG configuration from each host
@@ -4086,8 +4093,11 @@ sub check_configuration_difference {
                 my ($name, $setting) = @$cfg;
                 dprint ("$host->{'dbservice'} : $name, $setting \n" ) ;
                 $setting_ref = ($refserver{$name}//'ABSENT') ;
-                # Parameter is different, not ignored, and not excluded by --exclude
-                if ( ( $setting ne $setting_ref) and not exists $ignored{$name} ) {
+                # Parameter is different, not ignored, not 'N/A' on both sides,
+                # not excluded by --exclude
+                if ( ( $setting ne $setting_ref )
+                    and ( not exists $ignored{$name} )
+                    and ( $setting ne 'N/A' ) and ( $setting_ref ne 'N/A' ) ){
                     foreach my $exclude_regex ( @exclude_regexes ) {
                         next REC_PARAM if $name =~ /$exclude_regex/;
                     }

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -519,6 +519,7 @@ my %args = (
     'no_check_enable'       => 0,
     'no_check_track_counts' => 0,
     'ignore-wal-size'       => 0,
+    'ignore-paths'          => 0,
     'unarchiver'            => '',
     'save'                  => 0,
     'suffix'                => '',
@@ -536,6 +537,7 @@ my %args = (
     'relexclude'            => undef,
     'ok-on-standby'         => 0,
     'identical'             => 0,
+    'ignore-paths'          => 0
 );
 
 # Set name of the program without path*
@@ -4003,6 +4005,8 @@ By default it ignores a few parameters that will differ on a secondary:
 archive_mode,primary_conninfo,primary_slot_name.
 Force the check of all parameters with C<--identical>.
 
+C<--ignore-paths> ignore all differences in paths (data_directory, config_file, PID file, etc.)
+
 This service supports the argument C<--exclude REGEX> to exclude parameters
 matching the expression. You can use multiple C<--exclude REGEX> arguments.
 Eg : --exclude '(.*parallel.*|cluster_name|auto_explain.*|pg_stat_statements.*|work_mem)'
@@ -4033,9 +4037,18 @@ sub check_configuration_difference {
     my $setting_ref     = "";
     my @exclude_regexes = @{ $args{'exclude'} };
     my $identical       = $args{'identical'} ;
+    my $ignore_paths    = $args{'ignore-paths'} ;
     # will probably or always different on a primary & its secondary
-    my @ignored_if_secondary = ( 'archive_mode', 'in_hot_standby', 'primary_conninfo', 'primary_slot_name', 'transaction_read_only' ) ;
-    my $me              = 'POSTGRES_CONFIGURATION_DIFFERENCE';
+    my @ignored_if_secondary = ( 'archive_mode', 'in_hot_standby',
+                                 'primary_conninfo', 'primary_slot_name',
+                                 'transaction_read_only' ) ;
+    # the parameters contain paths that may differ on two different servers
+    # used by --ignore-paths
+    my @ignored_paths = ( 'config_file','data_directory','external_pid_file',
+                          'hba_file','ident_file', 'stats_temp_directory' ) ;
+    # always ignored
+    my @ignored_all = ('effective_wal_level');
+    my $me          = 'POSTGRES_CONFIGURATION_DIFFERENCE';
     my %queries = (
         $PG_VERSION_74 => q{
         SELECT name, setting
@@ -4051,9 +4064,11 @@ sub check_configuration_difference {
         -exitval => 127
     ) if @hosts < 2;
 
-    # ignored parameters hash
-    if ( $identical ne 1 ) { %ignored = map { $_ => 1 } ( @ignored_if_secondary) } ;
-    foreach my $key (keys %ignored) { dprint "IGNORED: $key \n"; };
+    # Compile the ignored parameters into a hash
+    if ( $identical ne 1 )     { @ignored_all = (@ignored_all, @ignored_if_secondary) } ;
+    if ( $ignore_paths eq 1 )  { @ignored_all = (@ignored_all, @ignored_paths) } ;
+    %ignored = map { $_ => 1 } ( @ignored_all) ;
+    # foreach my $key (keys %ignored) { print "IGNORED: $key \n"; };
 
     # Fetch configuration for each host ; compare each parameter to the one on the 1st host a reference
     foreach my $host (@hosts) {
@@ -10283,6 +10298,7 @@ GetOptions(
         'dbname|d=s',
         'dbservice|S=s',
         'identical!',
+        'ignore-paths!',
         'list|l!',
         'maintenance_work_mem=i',
         'no_check_autovacuum!',
@@ -10401,11 +10417,16 @@ pod2usage(
     -exitval => 127
 ) if scalar $args{'detailed'} and $args{'service'} ne 'oldest_xmin';
 
-# Check "check_difference" specific args --identical
+# Check specific args
 pod2usage(
     -message => 'FATAL: "identical" argument is only allowed with "configuration_difference" service.',
     -exitval => 127
 ) if scalar $args{'identical'} and $args{'service'} ne 'configuration_difference';
+
+pod2usage(
+    -message => 'FATAL: "ignore-paths" argument is only allowed with "configuration_difference" service.',
+    -exitval => 127
+) if scalar $args{'ignore-paths'} and $args{'service'} ne 'configuration_difference';
 
 
 # Set psql absolute path

--- a/check_pgactivity
+++ b/check_pgactivity
@@ -156,6 +156,10 @@ my %services = (
         'sub'  => \&check_configuration,
         'desc' => 'Check the most important settings.',
     },
+    'configuration_difference' => {
+        'sub'  => \&check_configuration_difference,
+        'desc' => 'Detect difference in cluster configuration.',
+    },
     'connection' => {
         'sub'  => \&check_connection,
         'desc' => 'Perform a simple connection test.'
@@ -242,6 +246,7 @@ my %services = (
         'sub'  => \&check_oldest_xmin,
         'desc' => 'Check the xmin horizon from distinct sources of xmin retention.'
     },
+
     'pga_version' => {
         'sub'  => \&check_pga_version,
         'desc' => 'Check the version of this check_pgactivity script.'
@@ -3982,6 +3987,114 @@ LOOP: foreach my $setting (@rc) {
     return status_ok( $me, [ "PostgreSQL configuration ok" ] );
 }
 
+
+=item B<configuration_difference>
+
+Check that the configuration is the same between two servers (according to pg_settings)
+By default, checks that the 1st server is a primary
+and the next one secondary that must be fully identical.
+
+Give the connection parameters with 2 or more services,
+eg. with --dbservices=pg1,pg2
+The first one is taken as the reference (usually a primary).
+
+By default it ignores archive_mode,primary_conninfo,primary_slot_name.
+Force the check with C<--identical>.
+
+This service supports the argument C<--exclude REGEX> to exclude parameters
+matching the expression. You can use multiple C<--exclude REGEX> arguments.
+Eg : --exclude '(.*parallel.*|cluster_name|auto_explain.*|pg_stat_statements.*|work_mem)'
+
+No perfdata
+
+Returns a Warning if some parameters are different.
+
+Required privileges: unprivileged role
+
+Known issues: roles configuration is ignored ;
+the connection role may hide the real configuration ;
+custom parameters (eg. demo.toto) are ignored if not declared by their extension.
+
+=cut
+
+sub check_configuration_difference {
+    my @perfdata;
+    my @msg;
+    my @msg_crit;
+    my @msg_warn;
+    my @hosts;
+    my @cfg;
+    my %refserver;
+    my %ignored;
+    my $nbdiff          = 0;
+    my %args            = %{ $_[0] };
+    my $num_clusters    = 0;
+    my $mess            = "";
+    my $setting_ref     = "";
+    my @exclude_regexes = @{ $args{'exclude'} };
+    # will probably or always different on a primary & its secondary
+    my @ignored_if_secondary = ( 'archive_mode', 'in_hot_standby', 'primary_conninfo', 'primary_slot_name', '(transaction_read_only' ) ;
+    my $me              = 'POSTGRES_CONFIGURATION_DIFFERENCE';
+    my %queries = (
+        $PG_VERSION_74 => q{
+        SELECT name, setting
+        FROM pg_settings
+        ORDER BY 1
+        }
+        );
+
+    @hosts = @{ parse_hosts %args };
+
+    pod2usage(
+        -message => 'FATAL: you must give two or more hosts with service "configuration_difference".',
+        -exitval => 127
+    ) if @hosts < 2;
+
+    # ignored parameters hash
+    %ignored = map { $_ => 1 } ( @ignored_if_secondary) ;
+    #if $args{'debug'} { foreach my $key (keys %ignored) { dprint "IGNORED: $key \n"; } };
+
+    # Fetch configuration for each host ; compare each parameter to the one on the 1st host a reference
+    foreach my $host (@hosts) {
+        $num_clusters ++;
+        dprint ("Cluster $num_clusters : $host->{'dbservice'} \n" );
+        # Fetch PG configuration from each host
+        $host->{'rs'} = \@{ query_ver( $host, %queries ) };
+        if ( $num_clusters == 1 ) {
+            # a hash table is more useful as the number of lines may in pg_settings may be different
+            %refserver = map { $_->[0] => $_->[1] } @{ $host->{'rs'} };
+        } else {
+            # Compare each setting with the setting from the first host
+            $nbdiff = 0;
+            REC_PARAM: foreach my $cfg ( @{$host->{'rs'}} ) {
+                my ($name, $setting) = @$cfg;
+                dprint ("$host->{'dbservice'} : $name, $setting \n" ) ;
+                $setting_ref = ($refserver{$name}//'ABSENT') ;
+                if ( ( $setting ne $setting_ref) and not exists $ignored{$name} ) {
+                    foreach my $exclude_regex ( @exclude_regexes ) {
+                        next REC_PARAM if $name =~ /$exclude_regex/;
+                    }
+                    dprint ("DIFF : $name : $setting vs: $setting_ref", "\n") ;
+                    $nbdiff ++ ; $mess = "" ;
+                    $mess = "[$host->{'dbservice'}] : " if $nbdiff == 1 ;
+                    if ( not defined $refserver{$name} ) {
+                        $mess = $mess."$name=$setting (ABSENT from $hosts[0]->{'dbservice'})";
+                    } else {
+                        $mess = $mess."$name=$setting (≠ $setting_ref)";
+                    }
+                    push @msg, $mess ;
+                }
+            }
+        }
+    }
+
+    return status_critical( $me, ['You need at least two cluster to compare their configurations.'] )
+        if $num_clusters < 2;
+
+    return status_warning( $me, \@msg) if @msg > 0;
+
+    return status_ok( $me, [ "$num_clusters Configurations checked :".join(' ', map { $_->{'dbservice'} } @hosts) ]);
+}
 
 =item B<connection> (all)
 


### PR DESCRIPTION
See issue #283 (option 1).

This is the 1st draft of a new service `configuration_difference` checks that two servers have the same configuration.
```
 ./check_pgactivity --dbservice=defo14,defo14-2  -s configuration_difference --ignore-paths 
POSTGRES_CONFIGURATION_DIFFERENCE WARNING: [defo14-2] : archive_command=(disabled) (≠ /bin/true), cluster_name=14/defo2 (≠ 14/defo), log_connections=off (≠ on), log_disconnections=off (≠ on), port=14012 (≠ 14001), shared_preload_libraries= (≠ pg_stat_statements), wal_keep_size=0 (≠ 100)
```

By default, it assumes that the 1st server in `--dbservice server1,server2` is a primary
and the others are secondaries that must be fully identical.

The check is based on `pg_settings`, as files in `pg_file_settings` are not always applied.

The monitoring user must not have some configuration that hides the server parameters, but usually a monitoring user has nothing important.

By default it ignores a few parameters that will almost always differ on a secondary:
`archive_mode,primary_conninfo,primary_slot_name`
(`in_hot_standby` and `transaction_read_only` too).
I've left `archive_command` and `restore_command`, they should be the same on a secondary ready for a failover.

`--identical`  allows to override this (sharding context?)

Some parameters will be always ignored (I've thought only of `effective_wal_level` in v19)

I'm probably not the only one with many test instances on the same server,
so I've added `--ignore-paths` to ignore all differences in paths.
I'm not sure about ignoring `cluster_name` too.

`--exclude`  works:
```
 --exclude '(.*parallel.*|cluster_name|auto_explain.*|pg_stat_statements.*|work_mem)'
```

Compatibility: no minimum version as `name`,`setting`  are there from 7.4 at least (I didn't test that far). If `pending_restart` may be of interest (add it in the message?), that would limit to 9.5+.

No perfdata : I don't see the point.

I'm not too sure about the output message format.

Returns a :yellow_circle: Warning if some parameters are different:
I've not thought of a case where a  small parameter difference is always a major problem  (or the secondary is already down).

Known limits:
- roles configurations are ignored (at least for now; not sure if this service is the place) ;
- the connection role may hide the "real" configuration as said above;
- custom parameters (eg. `demo.toto`) cannot be checked if not declared by their extension (they do not appear in pg_settings).

There is no test because I have no clue how it works and it's already late.


