### PR TITLE
New pg_hba_issues service

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -180,6 +180,10 @@ my %services = (
         'sub'  => \&check_extensions_versions,
         'desc' => 'Check that installed extensions are up-to-date.'
     },
+    'hba_settings' => {
+        'sub'  => \&check_hba_settings,
+        'desc' => 'Check issues in HBA configuration.'
+    },
     'hit_ratio' => {
         'sub'  => \&check_hit_ratio,
         'desc' => 'Check hit ratio on databases.'
@@ -2903,6 +2907,96 @@ sub check_checksum_errors {
     return status_warning( $me, \@msg_warn, \@perfdata ) if scalar @msg_warn > 0;
 
     return status_ok( $me, [ "$db_checked database(s) checked" ], \@perfdata );
+}
+
+=item B<hba_settings> (10+)
+
+Check for issues in the HBA configuration, reported in pg_hba_file_rules.
+
+Critical and Warning thresholds are optional. They only accept a raw number of
+errors.  If the thresholds are not provided, a default value of `1` will be
+used for both thresholds.
+
+Lines with error are CRITICAL issues, so it's highly recommended to keep
+default threshold, as immediate action should be taken as soon as such a
+problem arises.
+
+Lines with trust or password authentication are CRITICAL issues, and lines with
+md5 authentication are merely WARNING issues.
+
+Perfdata contains the number of lines per authentication method. Another
+perfdata gives the number of lines with errors.
+
+Required privileges: unprivileged user.
+
+=cut
+
+sub check_hba_settings {
+    my @msg_crit;
+    my @msg_warn;
+    my @rs;
+    my @perfdata;
+    my @hosts;
+    my %args    = %{ $_[0] };
+    my $me      = 'POSTGRES_HBA_SETTINGS';
+    my $nb_crit = 0;
+    my $nb_warn = 0;
+    my $sql     = q{WITH list AS (
+    SELECT 'error'::text, count(*) FROM pg_hba_file_rules WHERE error IS NOT NULL
+    UNION
+    SELECT auth_method, count(*) FROM pg_hba_file_rules WHERE auth_method IN ('trust', 'password', 'md5') GROUP BY 1)
+    SELECT * FROM list WHERE count>0};
+    my $w_limit;
+    my $c_limit;
+
+    # Warning and critical are optional
+    pod2usage(
+        -message => "FATAL: you must specify both critical and warning thresholds.",
+        -exitval => 127
+    ) if ((defined $args{'warning'} and not defined $args{'critical'})
+      or (not defined $args{'warning'} and defined $args{'critical'})) ;
+
+    # Warning and critical default to 1
+    if (not defined $args{'warning'} or not defined $args{'critical'}) {
+        $w_limit = $c_limit = 1;
+    } else {
+        $w_limit = $args{'warning'};
+        $c_limit = $args{'critical'};
+    }
+
+    @hosts = @{ parse_hosts %args };
+
+    pod2usage(
+        -message => 'FATAL: you must give only one host with service "hba_settings".',
+        -exitval => 127
+    ) if @hosts != 1;
+
+    is_compat $hosts[0], 'hba_settings', $PG_VERSION_100 or exit 1;
+
+    @rs = @{ query( $hosts[0], $sql ) };
+
+    LOOP: foreach my $line (@rs) {
+
+        push @perfdata => [ $line->[0], $line->[1], '', $w_limit, $c_limit ];
+
+        if ( $line->[1] >= $c_limit ) {
+            $nb_crit++;
+            next LOOP;
+        }
+
+        if ( $line->[1] >= $w_limit ) {
+            $nb_warn++;
+            next LOOP;
+        }
+    }
+
+    return status_critical( $me, [ "$nb_crit critical issue(s) found, $nb_warn warning issue(s) found" ], \@perfdata )
+        if $nb_crit > 0;
+
+    return status_warning( $me, [ "$nb_warn warning issue(s) found" ], \@perfdata )
+        if $nb_warn > 0;
+
+    return status_ok( $me, [ "No issue on hba files" ], \@perfdata );
 }
 
 =item B<backup_label_age> (8.1+)

--- a/t/01-hba_settings.t
+++ b/t/01-hba_settings.t
@@ -1,0 +1,104 @@
+#!/usr/bin/perl
+# This program is open source, licensed under the PostgreSQL License.
+# For license terms, see the LICENSE file.
+#
+# Copyright (C) 2012-2026: Open PostgreSQL Monitoring Development Group
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+use pgNode;
+use Test::More tests => 27;
+
+my $node        = pgNode->new('prod'); # declare instance named "prod"
+
+# create the instance and start it
+$node->init();
+$node->start;
+
+### Beginning of tests ###
+
+# simple check (trust everywhere, with initdb -A trust)
+$node->command_checks_all( [
+    './check_pgactivity', '--service'  => 'hba_settings',
+                          '--username' => $ENV{'USER'} || 'postgres',
+                          '--format'   => 'human'
+    ],
+    2,
+    [
+        qr/^Service  *: POSTGRES_HBA_SETTINGS$/m,
+        qr/^Returns  *: 2 \(CRITICAL\)$/m,
+        qr/^Message  *: 1 critical issue\(s\) found, 0 warning issue\(s\) found$/m,
+        qr/^Perfdata *: trust=6 warn=1 crit=1$/m,
+    ],
+    [ qr/^$/ ],
+    'simple issues check'
+);
+
+# Rip all the HBA config
+truncate $node->data_dir . '/' . 'pg_hba.conf', 0;
+
+# Add a simple one without error but a critical issue
+$node->append_conf('pg_hba.conf', "local all all trust");
+$node->reload;
+$node->command_checks_all( [
+    './check_pgactivity', '--service'  => 'hba_settings',
+                          '--username' => $ENV{'USER'} || 'postgres',
+                          '--format'   => 'human'
+    ],
+    2,
+    [
+        qr/^Service  *: POSTGRES_HBA_SETTINGS$/m,
+        qr/^Returns  *: 2 \(CRITICAL\)$/m,
+        qr/^Message  *: 1 critical issue\(s\) found, 0 warning issue\(s\) found$/m,
+        qr/^Perfdata *: trust=1 warn=1 crit=1$/m,
+    ],
+    [ qr/^$/ ],
+    'simple issues check'
+);
+
+# Add another simple one without error but another critical issue
+$node->append_conf('pg_hba.conf', "local all all md5");
+$node->reload;
+$node->command_checks_all( [
+    './check_pgactivity', '--service'  => 'hba_settings',
+                          '--username' => $ENV{'USER'} || 'postgres',
+                          '--format'   => 'human'
+    ],
+    2,
+    [
+        qr/^Service  *: POSTGRES_HBA_SETTINGS$/m,
+        qr/^Returns  *: 2 \(CRITICAL\)$/m,
+        qr/^Message  *: 2 critical issue\(s\) found, 0 warning issue\(s\) found$/m,
+        qr/^Perfdata *: trust=1 warn=1 crit=1$/m,
+        qr/^Perfdata *: md5=1 warn=1 crit=1$/m,
+    ],
+    [ qr/^$/ ],
+    'simple issues check'
+);
+
+# Add yet another one with an error
+$node->append_conf('pg_hba.conf', "host all all all 255.255.255.255 scram-sha-256");
+$node->reload;
+$node->command_checks_all( [
+    './check_pgactivity', '--service'  => 'hba_settings',
+                          '--username' => $ENV{'USER'} || 'postgres',
+                          '--format'   => 'human'
+    ],
+    2,
+    [
+        qr/^Service  *: POSTGRES_HBA_SETTINGS$/m,
+        qr/^Returns  *: 2 \(CRITICAL\)$/m,
+        qr/^Message  *: 3 critical issue\(s\) found, 0 warning issue\(s\) found$/m,
+        qr/^Perfdata *: error=1 warn=1 crit=1$/m,
+        qr/^Perfdata *: trust=1 warn=1 crit=1$/m,
+        qr/^Perfdata *: md5=1 warn=1 crit=1$/m,
+    ],
+    [ qr/^$/ ],
+    'simple issues check'
+);
+
+### End of tests ###
+
+$node->stop( 'immediate' );


### PR DESCRIPTION
It reports the number of errors reported in pg_hba_file_rules, and the number of rules with the trust, password, and md5 authentication methods. These methods are not recommended.

Warning and threshold values could be supplied, but this isn't recommended. All issues should be reported.

Fixes #374.