### PR TITLE
backup_label_age : Critical on PG15+ if backup_label exists

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -2907,14 +2907,23 @@ sub check_checksum_errors {
 
 =item B<backup_label_age> (8.1+)
 
-Check the age of the backup label file.
+Check the presence of backup label file (≥ PG15),
+or raise an alarm if it's too old (≤ PG14).
+
+Until PostgreSQL 14, a backup_label appears while a concurrent physical
+backup is running.
+Critical or Warning are raised if the age is above the thresholds
+(only intervals, eg. 1h30m25s).
+
+Thresholds are ignored on PostgreSQL 15 and above :
+the presence of a backup_label is an immediate failure (Critical),
+as this file should never be present on a running system
+and will prevent a restart.
 
 Perfdata returns the age of the backup_label file, -1 if not present.
 
-Critical and Warning thresholds only accept an interval (eg. 1h30m25s).
-
 Required privileges:
-grant execute on function pg_stat_file(text, boolean) (pg12+);
+GRANT EXECUTE ON FUNCTION pg_stat_file(text, boolean) (≥ PG 12);
 unprivileged role (9.3+); superuser (<9.3)
 
 =cut
@@ -2944,7 +2953,17 @@ sub check_backup_label_age {
         },
     );
 
-    # warning and critical are mandatory.
+    @hosts = @{ parse_hosts %args };
+
+    pod2usage(
+        -message => 'FATAL: you must give only one host with service "backup_label_age".',
+        -exitval => 127
+    ) if @hosts != 1;
+
+    is_compat $hosts[0], 'backup_label_age', $PG_VERSION_81 or exit 1;
+
+    if ( $hosts[0]->{'version_num'} < $PG_VERSION_150 ) {
+    # warning and critical are mandatory on ≤ PG14
     pod2usage(
         -message => "FATAL: you must specify critical and warning thresholds.",
         -exitval => 127
@@ -2958,15 +2977,6 @@ sub check_backup_label_age {
     $c_limit = get_time( $args{'critical'} );
     $w_limit = get_time( $args{'warning'} );
 
-    @hosts = @{ parse_hosts %args };
-
-    pod2usage(
-        -message => 'FATAL: you must give only one host with service "backup_label_age".',
-        -exitval => 127
-    ) if @hosts != 1;
-
-    is_compat $hosts[0], 'backup_label_age', $PG_VERSION_81 or exit 1;
-
     $rs = @{ query_ver( $hosts[0], %queries )->[0] }[0];
 
     push @perfdata, [ 'age', $rs, 's', $w_limit, $c_limit ];
@@ -2976,9 +2986,18 @@ sub check_backup_label_age {
 
     return status_warning( $me, [ "age: ".to_interval($rs) ], \@perfdata )
         if $rs > $w_limit;
+    }
+    else {
+            # PG15+ : backup_label must not exist
+            $rs = @{ query_ver( $hosts[0], %queries )->[0] }[0];
+            return status_critical( $me, [ "age: ".to_interval($rs) ], \@perfdata )
+                if $rs > 0;
+            return status_ok( $me, [ "backup_label file absent" ], \@perfdata );
+    }
 
     return status_ok( $me, [ "backup_label file ".( $rs == 0 ? "absent":"present (age: ".to_interval($rs).")") ], \@perfdata );
 }
+
 
 
 =item B<bgwriter> (8.3+)

--- a/t/01-backup_label_age.t
+++ b/t/01-backup_label_age.t
@@ -42,90 +42,130 @@ $node->start;
 
 ### Beginning of tests ###
 
-
-# basic check without thresholds
-$node->command_checks_all( [
-    './check_pgactivity', '--service'  => 'backup_label_age',
-                          '--username' => $ENV{'USER'} || 'postgres',
-                          '--format'   => 'human'
-    ],
-    127,
-    [ qr/^$/ ],
-    [ qr/^FATAL: you must specify critical and warning thresholds.$/m ],
-    'failing without thresholds'
-);
-
-# first check, with no backup being performed
-$node->command_checks_all( [
-    './check_pgactivity', '--service'  => 'backup_label_age',
-                          '--username' => $ENV{'USER'} || 'postgres',
-                          '--format'   => 'human',
-			  '--warning'  => '5s',
-			  '--critical' => '10s'
-    ],
-    0,
-    [ qr/^Service *: POSTGRES_BACKUP_LABEL_AGE$/m,
-      qr/^Returns *: 0 \(OK\)$/m,
-      qr/^Message *: backup_label file absent$/m,
-      qr/^Perfdata *: age=0s warn=5 crit=10$/m,
-     ],
-    [ qr/^$/ ],
-    'basic check'
-);
-
-# The following tests cases are only valid for pg<15.
-# Since exclusive backups were deprecated in pg15, we ignore this part
-# starting this release.
-if ($pgversion ge 15) {
-   # stop immediate to kill any remaining backends
-   $node->stop('immediate');
-   done_testing();
-   exit 0;
+if ($pgversion < 15) {
+    # basic check without thresholds (ignored on PG15+)
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'backup_label_age',
+                            '--username' => $ENV{'USER'} || 'postgres',
+                            '--format'   => 'human'
+        ],
+        127,
+        [ qr/^$/ ],
+        [ qr/^FATAL: you must specify critical and warning thresholds.$/m ],
+        'failing without thresholds'
+    );
 }
-push @procs, pgSession->new($node, 'postgres');
-
-$procs[0]->query('SELECT pg_start_backup(\'check_pga\')');
-
-sleep 1;
 
 # first check, with no backup being performed
-$node->command_checks_all( [
-    './check_pgactivity', '--service'  => 'backup_label_age',
-                          '--username' => $ENV{'USER'} || 'postgres',
-                          '--format'   => 'human',
-			  '--warning'  => '5s',
-			  '--critical' => '10s'
-    ],
-    0,
-    [ qr/^Service *: POSTGRES_BACKUP_LABEL_AGE$/m,
-      qr/^Returns *: 0 \(OK\)$/m,
-      qr/^Message *: backup_label file present \(age: \ds\)$/m,
-      qr/^Perfdata *: age=\ds warn=5 crit=10$/m,
-     ],
-    [ qr/^$/ ],
-    'basic check with exclusive backup'
-);
+if ($pgversion < 15 ) {
 
-sleep 3;
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'backup_label_age',
+                            '--username' => $ENV{'USER'} || 'postgres',
+                            '--format'   => 'human',
+                '--warning'  => '5s',
+                '--critical' => '10s'
+        ],
+        0,
+        [ qr/^Service *: POSTGRES_BACKUP_LABEL_AGE$/m,
+        qr/^Returns *: 0 \(OK\)$/m,
+        qr/^Message *: backup_label file absent$/m,
+        qr/^Perfdata *: age=0s warn=5 crit=10$/m,
+        ],
+        [ qr/^$/ ],
+        'basic check'
+    );
 
-$node->command_checks_all( [
-    './check_pgactivity', '--service'  => 'backup_label_age',
-                          '--username' => $ENV{'USER'} || 'postgres',
-                          '--format'   => 'human',
-			  '--warning'  => '2s',
-			  '--critical' => '10s'
-    ],
-    1,
-    [ qr/^Service *: POSTGRES_BACKUP_LABEL_AGE$/m,
-      qr/^Returns *: 1 \(WARNING\)$/m,
-      qr/^Message *: age: \ds$/m,
-      qr/^Perfdata *: age=\ds warn=2 crit=10$/m,
-     ],
-    [ qr/^$/ ],
-    'warn with exclusive backup'
-);
+} else {
 
-$procs[0]->query('SELECT pg_stop_backup()');
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'backup_label_age',
+                            '--username' => $ENV{'USER'} || 'postgres',
+                            '--format'   => 'human',
+                '--warning'  => '5s',
+                '--critical' => '10s'
+        ],
+        0,
+        [ qr/^Service *: POSTGRES_BACKUP_LABEL_AGE$/m,
+        qr/^Returns *: 0 \(OK\)$/m,
+        qr/^Message *: backup_label file absent$/m,
+        ],
+        [ qr/^$/ ],
+        'basic check'
+    );
+}
+
+if ($pgversion < 15) {
+
+    # tests with exclusive backup
+    push @procs, pgSession->new($node, 'postgres');
+
+    $procs[0]->query('SELECT pg_start_backup(\'check_pga\')');
+
+    sleep 1;
+
+    # first check, with no backup being performed
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'backup_label_age',
+                            '--username' => $ENV{'USER'} || 'postgres',
+                            '--format'   => 'human',
+                '--warning'  => '5s',
+                '--critical' => '10s'
+        ],
+        0,
+        [ qr/^Service *: POSTGRES_BACKUP_LABEL_AGE$/m,
+        qr/^Returns *: 0 \(OK\)$/m,
+        qr/^Message *: backup_label file present \(age: \ds\)$/m,
+        qr/^Perfdata *: age=\ds warn=5 crit=10$/m,
+        ],
+        [ qr/^$/ ],
+        'basic check with exclusive backup'
+    );
+
+    sleep 3;
+
+    $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'backup_label_age',
+                            '--username' => $ENV{'USER'} || 'postgres',
+                            '--format'   => 'human',
+                '--warning'  => '2s',
+                '--critical' => '10s'
+        ],
+        1,
+        [ qr/^Service *: POSTGRES_BACKUP_LABEL_AGE$/m,
+        qr/^Returns *: 1 \(WARNING\)$/m,
+        qr/^Message *: age: \ds$/m,
+        qr/^Perfdata *: age=\ds warn=2 crit=10$/m,
+        ],
+        [ qr/^$/ ],
+        'warn with exclusive backup'
+    );
+
+    $procs[0]->query('SELECT pg_stop_backup()');
+
+} else {
+
+        # PG 15+: backup_label should never be there,
+        # just simulate its presence
+        my $empty = $node->data_dir . '/backup_label';
+        open BACKUPLABELFILE, '>', $empty and close BACKUPLABELFILE
+        or die "File error with $empty: $!";
+        sleep 1;
+
+        $node->command_checks_all( [
+        './check_pgactivity', '--service'  => 'backup_label_age',
+                            '--username' => $ENV{'USER'} || 'postgres',
+                            '--format'   => 'human',
+        ],
+        2,
+        [ qr/^Service *: POSTGRES_BACKUP_LABEL_AGE$/m,
+        qr/^Returns *: 2 \(CRITICAL\)$/m,
+        qr/^Message *: age: \ds$/m,
+        ],
+        [ qr/^$/ ],
+        'critical with fake backup_label'
+    );
+}
 
 # stop immediate to kill any remaining backends
 $node->stop('immediate');


### PR DESCRIPTION
  Backup_label is not supposed to exist on a running PG15+ instance,
  as the concurrent backups do not exist anymore. Its presence still
  prevents a restart, so raise à Critical immediately.