### PR TITLE
Adds handling of errors in settings service

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -8135,11 +8135,11 @@ SLOTS_LOOP: foreach my $row (@rs) {
 =item B<settings> (9.0+)
 
 Check if the current settings have changed since they were stored in the
-service file.
+service file. Check also if there are errors in the configuration files.
 
-The "known" settings are recorded during the very first call of the service.
-To update the known settings after a configuration change, call this service
-again with the argument C<--save>.
+The "known" settings are recorded during the very first call of the service. If
+no error are found, you can update the known settings after a configuration
+change by calling this service again with the argument C<--save>.
 
 No perfdata.
 
@@ -8168,30 +8168,37 @@ sub check_settings {
     my $settings_lastedate;
     my %new_settings;
     my $pending_count = 0;
+    my $errors_count = 0;
     my %args  = %{ $_[0] };
     my $w_limit;
     my %queries = (
         $PG_VERSION_90 => q{
         SELECT coalesce(r.rolname, '*'), coalesce(d.datname, '*'),
           unnest(s.setconfig) AS setting,
-          false AS pending_restart
+          false AS pending_restart,
+          NULL AS error
         FROM pg_db_role_setting s
         LEFT JOIN pg_database d ON d.oid=s.setdatabase
         LEFT JOIN pg_roles r ON r.oid=s.setrole
         UNION ALL
-        SELECT '*', '*', name||'='||current_setting(name),false
+        SELECT '*', '*', name||'='||current_setting(name), false, NULL
         FROM pg_settings
        },
         $PG_VERSION_95 => q{
         SELECT coalesce(r.rolname, '*'), coalesce(d.datname, '*'),
           unnest(s.setconfig) AS setting,
-          false AS pending_restart
+          false AS pending_restart,
+          NULL AS error
         FROM pg_db_role_setting s
         LEFT JOIN pg_database d ON d.oid=s.setdatabase
         LEFT JOIN pg_roles r ON r.oid=s.setrole
         UNION ALL
-        SELECT '*', '*', name||'='||current_setting(name), pending_restart
+        SELECT '*', '*', name||'='||current_setting(name), pending_restart, NULL
         FROM pg_settings
+        UNION ALL
+        SELECT '*', '*', name||'='||setting, NULL, error||' in '||sourcefile||', line '||sourceline
+        FROM pg_file_settings
+        WHERE error IS NOT NULL
        }
     );
 
@@ -8209,14 +8216,20 @@ sub check_settings {
     $args{'save'} = 1 unless %settings;
 
 PARAM_LOOP: foreach my $row (@rs) {
-        my ( $rolname, $datname, $setting, $pending ) = @$row;
+        my ( $rolname, $datname, $setting, $pending, $error ) = @$row;
         my ( $name, $val ) = split /=/ => $setting, 2;
         my $prefix = "$rolname\@$datname";
         my $msg = "$setting";
 
+        if ( length($error) > 0 ) {
+            $errors_count++;
+            push @long_msg => "$error";
+            next PARAM_LOOP;
+        }
+
         if ( $pending eq "t" ) {
             $pending_count++;
-            push @long_msg => "$name is pending restart !";
+            push @long_msg => "$name is pending restart!";
         }
 
         $msg = "$prefix: $setting" unless $prefix eq '*@*';
@@ -8243,6 +8256,7 @@ PARAM_LOOP: foreach my $row (@rs) {
 
     $expected_result = 2 if scalar @long_msg;   # Regular warning
     $expected_result = 1 if $pending_count > 0; # Pending restart
+    $expected_result = 3 if $errors_count > 0;  # Errors
     $this_msg = join('\0', @long_msg);
     $settings_lastemsg = $settings_laste{'msg'} // "";
     $settings_lastedate = $settings_laste{'date'} // $now;
@@ -8262,10 +8276,13 @@ PARAM_LOOP: foreach my $row (@rs) {
         }
     }
 
-    if ( $args{'save'} ) {
+    if ( $args{'save'} and $errors_count == 0) {
         save $hosts[0], 'settings', \%new_settings, $args{'status-file'};
         return status_ok( $me, [ "Setting saved" ] )
     }
+
+    return status_critical( $me, [ 'Setting in error!' ], undef, \@long_msg )
+        if $expected_result == 3;
 
     return status_warning( $me, [ 'Setting changed and pending restart!' ], undef, \@long_msg )
         if $expected_result == 1;

--- a/t/01-settings.t
+++ b/t/01-settings.t
@@ -10,7 +10,7 @@ use warnings;
 use lib 't/lib';
 use pgNode;
 use TestLib ();
-use Test::More tests => 10;
+use Test::More tests => 16;
 
 my $node = pgNode->get_new_node('prod');
 my $pga_data = "$TestLib::tmp_check/pga.data";
@@ -52,6 +52,26 @@ $node->command_checks_all( [
     ],
     [ qr/^$/ ],
     'second basic check'
+);
+
+$node->append_conf('postgresql.conf', "work_mem=ahah");
+
+# Third check. Returns CRITICAL
+$node->command_checks_all( [
+    './check_pgactivity', '--service'     => 'settings',
+                          '--username'    => $ENV{'USER'} || 'postgres',
+                          '--format'      => 'human',
+                          '--status-file' => $pga_data,
+    ],
+    2,
+    [
+      qr/^Service  *: POSTGRES_SETTINGS$/m,
+      qr/^Returns  *: 2 \(CRITICAL\)$/m,
+      qr/^Message  *: Setting in error!$/m,
+      qr/^Long message  *: setting could not be applied in .*, line \d+$/m,
+    ],
+    [ qr/^$/ ],
+    'third basic check with an error'
 );
 
 ### End of tests ###


### PR DESCRIPTION
Check errors in file settings: postgresql.conf since 9.6, pg_hba.conf since 10, and pg_ident.conf since 15.

Perfdata contains the number of errors per files.

Thresholds, if any, are ignored.

Required privileges: unprivileged role.