### PR TITLE
Adds ident_settings service

### DIFF
--- a/check_pgactivity
+++ b/check_pgactivity
@@ -196,6 +196,10 @@ my %services = (
         'sub'  => \&check_hugepages,
         'desc' => 'Check if the hugepages are in the expected state.'
     },
+    'ident_settings' => {
+        'sub'  => \&check_ident_settings,
+        'desc' => 'Check errors in ident settings.'
+    },
     'invalid_indexes' => {
         'sub'  => \&check_invalid_indexes,
         'desc' => 'Check for invalid indexes.'
@@ -3732,6 +3736,72 @@ sub check_btree_bloat {
             if $w_count > 0;
 
     return status_ok( $me, [ "Btree bloat ok" ], \@perfdata );
+}
+
+
+=item B<ident_settings> (15+)
+
+Check errors in ident settings: pg_ident.conf and alike.
+
+Perfdata contains the number of errors per files.
+
+Thresholds, if any, are ignored.
+
+Required privileges: unprivileged role.
+
+=cut
+
+sub check_ident_settings {
+
+    my @rs;
+    my @perfdata;
+    my @msg;
+    my @longmsg;
+    my @hosts;
+    my %args         = %{ $_[0] };
+    my $me           = 'POSTGRES_IDENT_SETTINGS';
+    my $errors       = 0;
+
+    my %queries      = (
+        $PG_VERSION_150 => q{
+            SELECT NULL, line_number, error
+            FROM pg_ident_file_mappings
+            WHERE error IS NOT NULL
+            ORDER BY 1, 2, 3
+        },
+        $PG_VERSION_160 => q{
+            SELECT file_name, line_number, error
+            FROM pg_ident_file_mappings
+            WHERE error IS NOT NULL
+            ORDER BY 1, 2, 3
+        },
+    );
+
+    @hosts = @{ parse_hosts %args };
+
+    pod2usage(
+        -message => 'FATAL: you must give only one host with service "ident_settings".',
+        -exitval => 127
+    ) if @hosts != 1;
+
+    is_compat $hosts[0], 'ident_settings', $PG_VERSION_150 or exit 1;
+
+    @rs = @{ query_ver( $hosts[0], %queries ) };
+
+    REC_LOOP: foreach my $r (@rs) {
+        $errors++;
+        push @longmsg, "file ".$r->[0].", line ".$r->[1].", error: ".$r->[2];
+    }
+
+    push @perfdata, [ 'errors', $errors ];
+
+    if ($errors > 0) {
+        push @msg, "$errors error(s)";
+        return status_critical( $me, \@msg , \@perfdata, \@longmsg );
+    }
+
+    push @msg, "No errors in ident configuration files";
+    return status_ok( $me, \@msg , \@perfdata, \@longmsg );
 }
 
 

--- a/t/01-ident_settings.t
+++ b/t/01-ident_settings.t
@@ -1,0 +1,92 @@
+#!/usr/bin/perl
+# This program is open source, licensed under the PostgreSQL License.
+# For license terms, see the LICENSE file.
+#
+# Copyright (C) 2012-2026: Open PostgreSQL Monitoring Development Group
+
+use strict;
+use warnings;
+
+use lib 't/lib';
+use pgNode;
+use Test::More tests => 2;
+
+my $node        = pgNode->new('prod'); # declare instance named "prod"
+
+# create the instance and start it
+$node->init();
+$node->start;
+
+### Beginning of tests ###
+
+# Tests for PostreSQL 14 and before
+subtest pg14 => sub {
+    plan tests => 3;
+
+    SKIP: {
+        skip "testing incompatibility with PostgreSQL 14 and before", 3
+            unless $node->version <= 15.0;
+
+        $node->command_checks_all( [
+            './check_pgactivity', '--service'  => 'ident_settings',
+                                  '--username' => $ENV{'USER'} || 'postgres',
+                                  '--format'   => 'human'
+            ],
+            1,
+            [ qr/^$/ ],
+            [ qr/^Service ident_settings is not compatible with host/ ],
+            'non compatible PostgreSQL version'
+        );
+    }
+};
+
+subtest pg15 => sub {
+    plan tests => 12;
+
+    SKIP: {
+        skip "incompatible tests with PostgreSQL < 15", 12
+            unless $node->version >= 15.0;
+
+        # simple check
+        $node->command_checks_all( [
+            './check_pgactivity', '--service'  => 'ident_settings',
+                                  '--username' => $ENV{'USER'} || 'postgres',
+                                  '--format'   => 'human'
+            ],
+            0,
+            [
+                qr/^Service  *: POSTGRES_IDENT_SETTINGS$/m,
+                qr/^Returns  *: 0 \(OK\)$/m,
+                qr/^Message  *: No errors in ident configuration files$/m,
+            ],
+            [ qr/^$/ ],
+            'simple check with no error'
+        );
+
+        # Add a simple one with an error
+        $node->append_conf('pg_ident.conf', "foobar");
+
+        $node->command_checks_all( [
+            './check_pgactivity', '--service'  => 'ident_settings',
+                                  '--username' => $ENV{'USER'} || 'postgres',
+                                  '--format'   => 'human'
+            ],
+            2,
+            [
+                qr/^Service  *: POSTGRES_IDENT_SETTINGS$/m,
+                qr/^Returns  *: 2 \(CRITICAL\)$/m,
+                qr/^Message  *: 1 error\(s\)$/m,
+                qr/^Long message *: file .*, line \d+, error: .*$/m,
+                qr/^Perfdata *: errors=1$/m,
+            ],
+            [ qr/^$/ ],
+            'simple check with error'
+        );
+    }
+};
+
+done_testing;
+
+### End of tests ###
+
+$node->stop( 'immediate' );


### PR DESCRIPTION
Check errors in ident configuration files: pg_ident.conf and alike.

Perfdata contains the number of errors per files.

Thresholds, if any, are ignored.

Required privileges: unprivileged role.